### PR TITLE
Dropdown

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import {
   sortedGoalies,
 } from "./data/league/preSortedLeague";
 import StatOutputSizeButton from "./components/StatOutPutSizeButton";
+import DropDown from "./components/DropDown";
 
 function App() {
   // setCurrentLeagueSelector will be used to toggle between full league and position-based stats commented out for now
@@ -140,59 +141,60 @@ function App() {
         <div className="flex  justify-between items-center mb-4 ">
           <h2 className="">Current League</h2>
         </div>
-        <div className="grid [grid-template-columns:repeat(7,auto)]">
-          <>
-            {currentLeagueSelector === "full" ? (
-              <>
-                <div className="flex justify-end col-span-7 mb-2">
-                  <StatOutputSizeButton
-                    leagueSelection={skaterLeagueSelection}
-                    setLeagueSelection={(val) => {
-                      setSkaterLeagueSelection(val);
-                      setSkaterPage(1);
-                    }}
-                  />
-                </div>
-                <HeadingRow
-                  type="skater"
-                  roster={skaterRoster}
-                  setRoster={setSkaterRoster}
-                  sortState={skaterSort}
-                  setSortState={setSkaterSort}
+        <>
+          {currentLeagueSelector === "full" ? (
+            <DropDown title="Skaters">
+              <div className="flex justify-end col-span-7 mb-2">
+                <StatOutputSizeButton
+                  leagueSelection={skaterLeagueSelection}
+                  setLeagueSelection={(val) => {
+                    setSkaterLeagueSelection(val);
+                    setSkaterPage(1);
+                  }}
                 />
-                {skaterRoster
-                  .slice(
-                    skaterPage ===
-                      Math.max(
-                        1,
-                        Math.ceil(skaterRoster.length / skaterLeagueSelection)
-                      )
-                      ? Math.max(0, skaterRoster.length - skaterLeagueSelection)
-                      : (skaterPage - 1) * skaterLeagueSelection,
-                    skaterPage ===
-                      Math.max(
-                        1,
-                        Math.ceil(skaterRoster.length / skaterLeagueSelection)
-                      )
-                      ? skaterRoster.length
-                      : skaterPage * skaterLeagueSelection
-                  )
-                  .map((player, idx) => (
-                    <PlayerBar key={idx} player={player} />
-                  ))}
+              </div>
 
-                <StatPageNav
-                  pageChangeHandler={handlePageChange}
-                  page={skaterPage}
-                  type="skater"
-                  maxPage={Math.max(
-                    1,
-                    Math.ceil(skaterRoster.length / skaterLeagueSelection)
-                  )}
-                />
-              </>
-            ) : (
-              <>
+              <HeadingRow
+                type="skater"
+                roster={skaterRoster}
+                setRoster={setSkaterRoster}
+                sortState={skaterSort}
+                setSortState={setSkaterSort}
+              />
+              {skaterRoster
+                .slice(
+                  skaterPage ===
+                    Math.max(
+                      1,
+                      Math.ceil(skaterRoster.length / skaterLeagueSelection)
+                    )
+                    ? Math.max(0, skaterRoster.length - skaterLeagueSelection)
+                    : (skaterPage - 1) * skaterLeagueSelection,
+                  skaterPage ===
+                    Math.max(
+                      1,
+                      Math.ceil(skaterRoster.length / skaterLeagueSelection)
+                    )
+                    ? skaterRoster.length
+                    : skaterPage * skaterLeagueSelection
+                )
+                .map((player, idx) => (
+                  <PlayerBar key={idx} player={player} />
+                ))}
+
+              <StatPageNav
+                pageChangeHandler={handlePageChange}
+                page={skaterPage}
+                type="skater"
+                maxPage={Math.max(
+                  1,
+                  Math.ceil(skaterRoster.length / skaterLeagueSelection)
+                )}
+              />
+            </DropDown>
+          ) : (
+            <>
+              <DropDown title="Forwards">
                 <div className="flex justify-end col-span-7 mb-2">
                   <StatOutputSizeButton
                     leagueSelection={forwardsLeagueSelection}
@@ -245,6 +247,8 @@ function App() {
                     Math.ceil(forwardsRoster.length / forwardsLeagueSelection)
                   )}
                 />
+              </DropDown>
+              <DropDown title="Defensemen">
                 <div className="flex justify-end col-span-7 mb-2">
                   <StatOutputSizeButton
                     leagueSelection={defensemenLeagueSelection}
@@ -299,8 +303,10 @@ function App() {
                     )
                   )}
                 />
-              </>
-            )}
+              </DropDown>
+            </>
+          )}
+          <DropDown title="Goalies">
             <div className="flex justify-end col-span-7 mb-2">
               <StatOutputSizeButton
                 leagueSelection={goalieLeagueSelection}
@@ -346,8 +352,8 @@ function App() {
                 Math.ceil(goalieRoster.length / goalieLeagueSelection)
               )}
             />
-          </>
-        </div>
+          </DropDown>
+        </>
       </div>
     </div>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,8 +9,8 @@ import {
   sortedDefensemen,
   sortedGoalies,
 } from "./data/league/preSortedLeague";
-import StatOutputSizeButton from "./components/StatOutPutSizeButton";
-import DropDown from "./components/DropDown";
+import StatsDropDown from "./components/DropDown";
+import type { Player } from "./types/player";
 
 function App() {
   // setCurrentLeagueSelector will be used to toggle between full league and position-based stats commented out for now
@@ -34,10 +34,12 @@ function App() {
   // };
 
   // Roster and sort state
-  const [skaterRoster, setSkaterRoster] = useState(sortedRoster);
-  const [goalieRoster, setGoalieRoster] = useState(sortedGoalies);
-  const [forwardsRoster, setForwardsRoster] = useState(sortedForwards);
-  const [defensemenRoster, setDefensemenRoster] = useState(sortedDefensemen);
+  const [skaterRoster, setSkaterRoster] = useState<Player[]>(sortedRoster);
+  const [goalieRoster, setGoalieRoster] = useState<Player[]>(sortedGoalies);
+  const [forwardsRoster, setForwardsRoster] =
+    useState<Player[]>(sortedForwards);
+  const [defensemenRoster, setDefensemenRoster] =
+    useState<Player[]>(sortedDefensemen);
   const [skaterPage, setSkaterPage] = useState(1);
   const [goaliePage, setGoaliePage] = useState(1);
   const [forwardsPage, setForwardsPage] = useState(1);
@@ -141,219 +143,206 @@ function App() {
         <div className="flex  justify-between items-center mb-4 ">
           <h2 className="">Current League</h2>
         </div>
-        <>
-          {currentLeagueSelector === "full" ? (
-            <DropDown title="Skaters">
-              <div className="flex justify-end col-span-7 mb-2">
-                <StatOutputSizeButton
-                  leagueSelection={skaterLeagueSelection}
-                  setLeagueSelection={(val) => {
-                    setSkaterLeagueSelection(val);
-                    setSkaterPage(1);
-                  }}
+        <div className="flex flex-col md:gap-2 w-full">
+          <>
+            {currentLeagueSelector === "full" ? (
+              <StatsDropDown
+                title="Skaters"
+                leagueSelection={skaterLeagueSelection}
+                setLeagueSelection={setSkaterLeagueSelection}
+                setPage={() => setSkaterPage(1)}
+              >
+                <HeadingRow
+                  type="skater"
+                  roster={skaterRoster as Player[]}
+                  setRoster={(r: Player[]) =>
+                    setSkaterRoster(r as typeof skaterRoster)
+                  }
+                  sortState={skaterSort}
+                  setSortState={setSkaterSort}
                 />
-              </div>
 
+                {skaterRoster
+                  .slice(
+                    skaterPage ===
+                      Math.max(
+                        1,
+                        Math.ceil(skaterRoster.length / skaterLeagueSelection)
+                      )
+                      ? Math.max(0, skaterRoster.length - skaterLeagueSelection)
+                      : (skaterPage - 1) * skaterLeagueSelection,
+                    skaterPage ===
+                      Math.max(
+                        1,
+                        Math.ceil(skaterRoster.length / skaterLeagueSelection)
+                      )
+                      ? skaterRoster.length
+                      : skaterPage * skaterLeagueSelection
+                  )
+                  .map((player, idx) => (
+                    <PlayerBar key={idx} player={player} />
+                  ))}
+                <StatPageNav
+                  pageChangeHandler={handlePageChange}
+                  page={skaterPage}
+                  type="skater"
+                  maxPage={Math.max(
+                    1,
+                    Math.ceil(skaterRoster.length / skaterLeagueSelection)
+                  )}
+                />
+              </StatsDropDown>
+            ) : (
+              <>
+                <StatsDropDown
+                  title="Forwards"
+                  leagueSelection={forwardsLeagueSelection}
+                  setLeagueSelection={setForwardsLeagueSelection}
+                  setPage={() => setForwardsPage(1)}
+                >
+                  <HeadingRow
+                    type="forwards"
+                    roster={forwardsRoster}
+                    setRoster={(r: Player[]) => setForwardsRoster(r)}
+                    sortState={forwardsSort}
+                    setSortState={setForwardsSort}
+                  />
+                  {forwardsRoster
+                    .slice(
+                      forwardsPage ===
+                        Math.max(
+                          1,
+                          Math.ceil(
+                            forwardsRoster.length / forwardsLeagueSelection
+                          )
+                        )
+                        ? Math.max(
+                            0,
+                            forwardsRoster.length - forwardsLeagueSelection
+                          )
+                        : (forwardsPage - 1) * forwardsLeagueSelection,
+                      forwardsPage ===
+                        Math.max(
+                          1,
+                          Math.ceil(
+                            forwardsRoster.length / forwardsLeagueSelection
+                          )
+                        )
+                        ? forwardsRoster.length
+                        : forwardsPage * forwardsLeagueSelection
+                    )
+                    .map((player, idx) => (
+                      <PlayerBar key={idx} player={player} />
+                    ))}
+                  <StatPageNav
+                    pageChangeHandler={handlePageChange}
+                    page={forwardsPage}
+                    type="forwards"
+                    maxPage={Math.max(
+                      1,
+                      Math.ceil(forwardsRoster.length / forwardsLeagueSelection)
+                    )}
+                  />
+                </StatsDropDown>
+                <StatsDropDown
+                  title="Defensemen"
+                  leagueSelection={defensemenLeagueSelection}
+                  setLeagueSelection={setDefensemenLeagueSelection}
+                  setPage={() => setDefensemenPage(1)}
+                >
+                  <HeadingRow
+                    type="defensemen"
+                    roster={defensemenRoster}
+                    setRoster={(r: Player[]) => setDefensemenRoster(r)}
+                    sortState={defensemenSort}
+                    setSortState={setDefensemenSort}
+                  />
+                  {defensemenRoster
+                    .slice(
+                      defensemenPage ===
+                        Math.max(
+                          1,
+                          Math.ceil(
+                            defensemenRoster.length / defensemenLeagueSelection
+                          )
+                        )
+                        ? Math.max(
+                            0,
+                            defensemenRoster.length - defensemenLeagueSelection
+                          )
+                        : (defensemenPage - 1) * defensemenLeagueSelection,
+                      defensemenPage ===
+                        Math.max(
+                          1,
+                          Math.ceil(
+                            defensemenRoster.length / defensemenLeagueSelection
+                          )
+                        )
+                        ? defensemenRoster.length
+                        : defensemenPage * defensemenLeagueSelection
+                    )
+                    .map((player, idx) => (
+                      <PlayerBar key={idx} player={player} />
+                    ))}
+                  <StatPageNav
+                    pageChangeHandler={handlePageChange}
+                    page={defensemenPage}
+                    type="defensemen"
+                    maxPage={Math.max(
+                      1,
+                      Math.ceil(
+                        defensemenRoster.length / defensemenLeagueSelection
+                      )
+                    )}
+                  />
+                </StatsDropDown>
+              </>
+            )}
+            <StatsDropDown
+              title="Goalies"
+              leagueSelection={goalieLeagueSelection}
+              setLeagueSelection={setGoalieLeagueSelection}
+              setPage={() => setGoaliePage(1)}
+            >
               <HeadingRow
-                type="skater"
-                roster={skaterRoster}
-                setRoster={setSkaterRoster}
-                sortState={skaterSort}
-                setSortState={setSkaterSort}
+                type="goalie"
+                roster={goalieRoster}
+                setRoster={(r: Player[]) => setGoalieRoster(r)}
+                sortState={goalieSort}
+                setSortState={setGoalieSort}
               />
-              {skaterRoster
+              {goalieRoster
                 .slice(
-                  skaterPage ===
+                  goaliePage ===
                     Math.max(
                       1,
-                      Math.ceil(skaterRoster.length / skaterLeagueSelection)
+                      Math.ceil(goalieRoster.length / goalieLeagueSelection)
                     )
-                    ? Math.max(0, skaterRoster.length - skaterLeagueSelection)
-                    : (skaterPage - 1) * skaterLeagueSelection,
-                  skaterPage ===
+                    ? Math.max(0, goalieRoster.length - goalieLeagueSelection)
+                    : (goaliePage - 1) * goalieLeagueSelection,
+                  goaliePage ===
                     Math.max(
                       1,
-                      Math.ceil(skaterRoster.length / skaterLeagueSelection)
+                      Math.ceil(goalieRoster.length / goalieLeagueSelection)
                     )
-                    ? skaterRoster.length
-                    : skaterPage * skaterLeagueSelection
+                    ? goalieRoster.length
+                    : goaliePage * goalieLeagueSelection
                 )
                 .map((player, idx) => (
                   <PlayerBar key={idx} player={player} />
                 ))}
-
               <StatPageNav
                 pageChangeHandler={handlePageChange}
-                page={skaterPage}
-                type="skater"
+                page={goaliePage}
+                type="goalie"
                 maxPage={Math.max(
                   1,
-                  Math.ceil(skaterRoster.length / skaterLeagueSelection)
+                  Math.ceil(goalieRoster.length / goalieLeagueSelection)
                 )}
               />
-            </DropDown>
-          ) : (
-            <>
-              <DropDown title="Forwards">
-                <div className="flex justify-end col-span-7 mb-2">
-                  <StatOutputSizeButton
-                    leagueSelection={forwardsLeagueSelection}
-                    setLeagueSelection={(val) => {
-                      setForwardsLeagueSelection(val);
-                      setForwardsPage(1);
-                    }}
-                  />
-                </div>
-                <HeadingRow
-                  type="forwards"
-                  roster={forwardsRoster}
-                  setRoster={setForwardsRoster}
-                  sortState={forwardsSort}
-                  setSortState={setForwardsSort}
-                />
-                {forwardsRoster
-                  .slice(
-                    forwardsPage ===
-                      Math.max(
-                        1,
-                        Math.ceil(
-                          forwardsRoster.length / forwardsLeagueSelection
-                        )
-                      )
-                      ? Math.max(
-                          0,
-                          forwardsRoster.length - forwardsLeagueSelection
-                        )
-                      : (forwardsPage - 1) * forwardsLeagueSelection,
-                    forwardsPage ===
-                      Math.max(
-                        1,
-                        Math.ceil(
-                          forwardsRoster.length / forwardsLeagueSelection
-                        )
-                      )
-                      ? forwardsRoster.length
-                      : forwardsPage * forwardsLeagueSelection
-                  )
-                  .map((player, idx) => (
-                    <PlayerBar key={idx} player={player} />
-                  ))}
-                <StatPageNav
-                  pageChangeHandler={handlePageChange}
-                  page={forwardsPage}
-                  type="forwards"
-                  maxPage={Math.max(
-                    1,
-                    Math.ceil(forwardsRoster.length / forwardsLeagueSelection)
-                  )}
-                />
-              </DropDown>
-              <DropDown title="Defensemen">
-                <div className="flex justify-end col-span-7 mb-2">
-                  <StatOutputSizeButton
-                    leagueSelection={defensemenLeagueSelection}
-                    setLeagueSelection={(val) => {
-                      setDefensemenLeagueSelection(val);
-                      setDefensemenPage(1);
-                    }}
-                  />
-                </div>
-                <HeadingRow
-                  type="defensemen"
-                  roster={defensemenRoster}
-                  setRoster={setDefensemenRoster}
-                  sortState={defensemenSort}
-                  setSortState={setDefensemenSort}
-                />
-                {defensemenRoster
-                  .slice(
-                    defensemenPage ===
-                      Math.max(
-                        1,
-                        Math.ceil(
-                          defensemenRoster.length / defensemenLeagueSelection
-                        )
-                      )
-                      ? Math.max(
-                          0,
-                          defensemenRoster.length - defensemenLeagueSelection
-                        )
-                      : (defensemenPage - 1) * defensemenLeagueSelection,
-                    defensemenPage ===
-                      Math.max(
-                        1,
-                        Math.ceil(
-                          defensemenRoster.length / defensemenLeagueSelection
-                        )
-                      )
-                      ? defensemenRoster.length
-                      : defensemenPage * defensemenLeagueSelection
-                  )
-                  .map((player, idx) => (
-                    <PlayerBar key={idx} player={player} />
-                  ))}
-                <StatPageNav
-                  pageChangeHandler={handlePageChange}
-                  page={defensemenPage}
-                  type="defensemen"
-                  maxPage={Math.max(
-                    1,
-                    Math.ceil(
-                      defensemenRoster.length / defensemenLeagueSelection
-                    )
-                  )}
-                />
-              </DropDown>
-            </>
-          )}
-          <DropDown title="Goalies">
-            <div className="flex justify-end col-span-7 mb-2">
-              <StatOutputSizeButton
-                leagueSelection={goalieLeagueSelection}
-                setLeagueSelection={(val) => {
-                  setGoalieLeagueSelection(val);
-                  setGoaliePage(1);
-                }}
-              />
-            </div>
-            <HeadingRow
-              type="goalie"
-              roster={goalieRoster}
-              setRoster={setGoalieRoster}
-              sortState={goalieSort}
-              setSortState={setGoalieSort}
-            />
-            {goalieRoster
-              .slice(
-                goaliePage ===
-                  Math.max(
-                    1,
-                    Math.ceil(goalieRoster.length / goalieLeagueSelection)
-                  )
-                  ? Math.max(0, goalieRoster.length - goalieLeagueSelection)
-                  : (goaliePage - 1) * goalieLeagueSelection,
-                goaliePage ===
-                  Math.max(
-                    1,
-                    Math.ceil(goalieRoster.length / goalieLeagueSelection)
-                  )
-                  ? goalieRoster.length
-                  : goaliePage * goalieLeagueSelection
-              )
-              .map((player, idx) => (
-                <PlayerBar key={idx} player={player} />
-              ))}
-            <StatPageNav
-              pageChangeHandler={handlePageChange}
-              page={goaliePage}
-              type="goalie"
-              maxPage={Math.max(
-                1,
-                Math.ceil(goalieRoster.length / goalieLeagueSelection)
-              )}
-            />
-          </DropDown>
-        </>
+            </StatsDropDown>
+          </>
+        </div>
       </div>
     </div>
   );

--- a/src/__tests__/src/components/DropDown.test.tsx
+++ b/src/__tests__/src/components/DropDown.test.tsx
@@ -1,0 +1,138 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import StatsDropDown from "@/components/DropDown";
+
+describe("StatsDropDown", () => {
+  const mockSetLeagueSelection = jest.fn();
+  const mockSetPage = jest.fn();
+
+  const defaultProps = {
+    title: "Test Dropdown",
+    leagueSelection: 10 as const,
+    setLeagueSelection: mockSetLeagueSelection,
+    setPage: mockSetPage,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("renders dropdown title", () => {
+    render(
+      <StatsDropDown {...defaultProps}>
+        <div>Test content</div>
+      </StatsDropDown>
+    );
+    expect(screen.getByText("Test Dropdown")).toBeInTheDocument();
+  });
+
+  test("renders children when expanded", () => {
+    const { container } = render(
+      <StatsDropDown {...defaultProps}>
+        <div>Test content</div>
+      </StatsDropDown>
+    );
+
+    // Click to expand using the ddbutton class
+    const ddButton = container.querySelector(".ddbutton");
+    if (ddButton) {
+      fireEvent.click(ddButton);
+    } else {
+      throw new Error("Dropdown button not found");
+    }
+
+    expect(screen.getByText("Test content")).toBeInTheDocument();
+  });
+
+  test("toggles dropdown when clicked", () => {
+    const { container } = render(
+      <StatsDropDown {...defaultProps}>
+        <div>Test content</div>
+      </StatsDropDown>
+    );
+
+    // Get the main dropdown button using class selector
+    const button = container.querySelector(".ddbutton");
+    if (!button) throw new Error("Dropdown button not found");
+
+    const animatedDiv = container.querySelector(".grid.w-full.overflow-hidden");
+
+    // Initially closed - should have closed classes
+    expect(animatedDiv).toHaveClass("grid-rows-[0fr]", "opacity-0");
+
+    // Click to open
+    fireEvent.click(button);
+    expect(animatedDiv).toHaveClass("grid-rows-[1fr]", "opacity-100");
+
+    // Click to close
+    fireEvent.click(button);
+    expect(animatedDiv).toHaveClass("grid-rows-[0fr]", "opacity-0");
+  });
+
+  test("displays current league selection value", () => {
+    const { container } = render(
+      <StatsDropDown {...defaultProps} leagueSelection={25}>
+        <div>Test content</div>
+      </StatsDropDown>
+    );
+
+    // Target the visible main league selection button specifically
+    const visibleButton = container.querySelector("button.visible");
+    expect(visibleButton).toBeInTheDocument();
+    expect(visibleButton).toHaveTextContent("25");
+  });
+
+  test("calls setPage when league selection changes", () => {
+    const { container } = render(
+      <StatsDropDown {...defaultProps}>
+        <div>Test content</div>
+      </StatsDropDown>
+    );
+
+    // Click the visible league selection button to open dropdown
+    const visibleButton = container.querySelector("button.visible");
+    if (visibleButton) {
+      fireEvent.click(visibleButton);
+    }
+
+    // Click on a different option (find the option that's not hidden and not the current selection)
+    const option25 = container.querySelector(
+      "button:not(.hidden):not(.visible)"
+    );
+    if (option25 && option25.textContent === "25") {
+      fireEvent.click(option25);
+      expect(mockSetPage).toHaveBeenCalled();
+    }
+  });
+
+  test("applies correct CSS classes for animation", () => {
+    const { container } = render(
+      <StatsDropDown {...defaultProps}>
+        <div>Test content</div>
+      </StatsDropDown>
+    );
+
+    const animatedDiv = container.querySelector(".grid.w-full.overflow-hidden");
+    expect(animatedDiv).toHaveClass("grid-rows-[0fr]", "opacity-0");
+
+    // Click to expand using ddbutton class
+    const button = container.querySelector(".ddbutton");
+    if (button) {
+      fireEvent.click(button);
+    }
+
+    expect(animatedDiv).toHaveClass("grid-rows-[1fr]", "opacity-100");
+  });
+
+  test("renders StatOutputSizeButton with correct props", () => {
+    const { container } = render(
+      <StatsDropDown {...defaultProps} leagueSelection={50}>
+        <div>Test content</div>
+      </StatsDropDown>
+    );
+
+    // The visible button should show the current selection
+    const visibleButton = container.querySelector("button.visible");
+    expect(visibleButton).toBeInTheDocument();
+    expect(visibleButton).toHaveTextContent("50");
+  });
+});

--- a/src/__tests__/src/components/StatEntry.test.tsx
+++ b/src/__tests__/src/components/StatEntry.test.tsx
@@ -34,6 +34,8 @@ describe("StatEntry", () => {
     render(<StatEntry stat="USA" side="right" />);
     const element = screen.getByText("USA");
     expect(element).toHaveClass("text-right");
-    expect(element).toHaveClass("px-1 md:px-4");
+    expect(element).toHaveClass(
+      "whitespace-nowrap px-1 border-1 border-gray-300"
+    );
   });
 });

--- a/src/components/Chevron.tsx
+++ b/src/components/Chevron.tsx
@@ -1,0 +1,19 @@
+export default function Chevron({ down = false }: { down?: boolean }) {
+  return (
+    <svg
+      className="inline-block w-6 h-6 transform transition-transform duration-800"
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      style={{ transform: down ? "rotateX(0deg)" : "rotateX(180deg)" }}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M19 9l-7 7-7-7"
+      />
+    </svg>
+  );
+}

--- a/src/components/DropDown.tsx
+++ b/src/components/DropDown.tsx
@@ -19,7 +19,7 @@ export default function StatsDropDown({
   return (
     <div className="relative inline-block text-left w-full h-fit">
       <button
-        className="w-full flex justify-between items-center px-4 py-2 text-sm font-medium bg-white border border-gray-300 rounded-md shadow-sm hover:bg-gray-50 focus:outline-none"
+        className="ddbutton w-full flex justify-between items-center px-4 py-2 text-sm font-medium bg-white border border-gray-300 rounded-md shadow-sm hover:bg-gray-50 focus:outline-none"
         onClick={() => {
           setOpen((prev) => !prev);
         }}

--- a/src/components/DropDown.tsx
+++ b/src/components/DropDown.tsx
@@ -1,0 +1,30 @@
+import { useState } from "react";
+
+export default function DropDown({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="relative inline-block text-left w-full">
+      <button
+        className="w-full"
+        onClick={() => {
+          setOpen((prev) => !prev);
+        }}
+      >
+        {title}
+      </button>
+
+      <div className={`${open ? "block" : "hidden"} w-full`}>
+        {" "}
+        <div className="grid [grid-template-columns:repeat(7,auto)]">
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/DropDown.tsx
+++ b/src/components/DropDown.tsx
@@ -43,7 +43,7 @@ export default function StatsDropDown({
         }`}
       >
         <div className="overflow-hidden">
-          <div className="grid [grid-template-columns:repeat(7,auto)]">
+          <div className="grid [grid-template-columns:1fr_auto_auto_auto_auto_auto_auto]">
             {children}
           </div>
         </div>

--- a/src/components/DropDown.tsx
+++ b/src/components/DropDown.tsx
@@ -1,28 +1,51 @@
 import { useState } from "react";
+import Chevron from "./Chevron";
+import StatOutputSizeButton from "./StatOutPutSizeButton";
 
-export default function DropDown({
+export default function StatsDropDown({
   title,
   children,
+  leagueSelection,
+  setLeagueSelection,
+  setPage,
 }: {
   title: string;
   children: React.ReactNode;
+  leagueSelection: 10 | 25 | 50 | 100;
+  setLeagueSelection: React.Dispatch<React.SetStateAction<10 | 25 | 50 | 100>>;
+  setPage: () => void;
 }) {
   const [open, setOpen] = useState(false);
   return (
-    <div className="relative inline-block text-left w-full">
+    <div className="relative inline-block text-left w-full h-fit">
       <button
-        className="w-full"
+        className="w-full flex justify-between items-center px-4 py-2 text-sm font-medium bg-white border border-gray-300 rounded-md shadow-sm hover:bg-gray-50 focus:outline-none"
         onClick={() => {
           setOpen((prev) => !prev);
         }}
       >
-        {title}
+        <div className="flex justify-start items-center gap-4">
+          {title}
+          <StatOutputSizeButton
+            leagueSelection={leagueSelection}
+            setLeagueSelection={(val) => {
+              setLeagueSelection(val);
+              setPage();
+            }}
+          />
+        </div>
+        <Chevron down={open} />
       </button>
 
-      <div className={`${open ? "block" : "hidden"} w-full`}>
-        {" "}
-        <div className="grid [grid-template-columns:repeat(7,auto)]">
-          {children}
+      <div
+        className={`grid w-full overflow-hidden transition-all duration-500 ${
+          open ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0"
+        }`}
+      >
+        <div className="overflow-hidden">
+          <div className="grid [grid-template-columns:repeat(7,auto)]">
+            {children}
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/HeadingEntry.tsx
+++ b/src/components/HeadingEntry.tsx
@@ -2,15 +2,19 @@ export default function HeadingEntry({
   label,
   sortHandler,
   side = "center",
+  size = "lg",
 }: {
   label: string;
   sortHandler?: () => void;
   side?: "left" | "center" | "right";
+  size?: "sm" | "md" | "lg";
 }) {
   return (
     <p
       onClick={sortHandler}
-      className={`text-${side} px-1 md:px-4 font-extrabold border-x-2 border-y-4 text-black border-gray-800 bg-neutral-300 hover:bg-neutral-400 cursor-pointer transition-colors duration-200`}
+      className={`text-${side} ${
+        size === "md" ? "w-10" : size === "sm" ? "w-10" : ""
+      }  font-extrabold px-1 border-x-2 border-y-4 text-black border-gray-800 bg-neutral-300 hover:bg-neutral-400 cursor-pointer transition-colors duration-200`}
     >
       {label}
     </p>

--- a/src/components/HeadingRow.tsx
+++ b/src/components/HeadingRow.tsx
@@ -56,26 +56,31 @@ export default function HeadingRow({
             label="Pos"
             side="left"
             sortHandler={() => sort("position")}
+            size="md"
           />
           <HeadingEntry
             label="GP"
             side="right"
             sortHandler={() => sort("gamesPlayed")}
+            size="sm"
           />
           <HeadingEntry
             label="G"
             side="right"
             sortHandler={() => sort("goals")}
+            size="sm"
           />
           <HeadingEntry
             label="A"
             side="right"
             sortHandler={() => sort("assists")}
+            size="sm"
           />
           <HeadingEntry
             label="Pts"
             side="right"
             sortHandler={() => sort("points")}
+            size="sm"
           />
         </>
       ) : type === "goalie" ? (
@@ -94,26 +99,31 @@ export default function HeadingRow({
             label="Pos"
             side="left"
             sortHandler={() => sort("position")}
+            size="md"
           />
           <HeadingEntry
             label="GP"
             side="right"
             sortHandler={() => sort("gamesPlayed")}
+            size="sm"
           />
           <HeadingEntry
             label="W"
             side="right"
             sortHandler={() => sort("wins")}
+            size="sm"
           />
           <HeadingEntry
             label="Pct"
             side="right"
             sortHandler={() => sort("savePercentage")}
+            size="sm"
           />
           <HeadingEntry
             label="GA"
             side="right"
             sortHandler={() => sort("goalsAgainstAvg")}
+            size="sm"
           />
         </>
       ) : type === "defensemen" ? null : type === "forwards" ? null : null}

--- a/src/components/PlayerBar.tsx
+++ b/src/components/PlayerBar.tsx
@@ -11,18 +11,21 @@ export default function PlayerBar({ player }: { player: Player }) {
             side="left"
           />
           <StatEntry stat={player.nationality} side="left" />
-          <StatEntry stat={player.position} side="left" />
-          <StatEntry stat={player.stats.gamesPlayed} side="right" />
-          <StatEntry stat={player.stats.wins} side="right" />
+
+          <StatEntry stat={player.position} side="left" size={"md"} />
+          <StatEntry stat={player.stats.gamesPlayed} side="right" size={"sm"} />
+          <StatEntry stat={player.stats.wins} side="right" size={"sm"} />
           <StatEntry
             stat={player.stats.savePercentage}
             side="right"
             round={3}
+            size={"sm"}
           />
           <StatEntry
             stat={player.stats.goalsAgainstAvg}
             side="right"
             round={2}
+            size={"sm"}
           />
         </>
       ) : (
@@ -32,11 +35,11 @@ export default function PlayerBar({ player }: { player: Player }) {
             side="left"
           />
           <StatEntry stat={player.nationality} side="left" />
-          <StatEntry stat={player.position} side="left" />
-          <StatEntry stat={player.stats.gamesPlayed} side="right" />
-          <StatEntry stat={player.stats.goals} side="right" />
-          <StatEntry stat={player.stats.assists} side="right" />
-          <StatEntry stat={player.stats.points} side="right" />
+          <StatEntry stat={player.position} side="left" size={"md"} />
+          <StatEntry stat={player.stats.gamesPlayed} side="right" size={"sm"} />
+          <StatEntry stat={player.stats.goals} side="right" size={"sm"} />
+          <StatEntry stat={player.stats.assists} side="right" size={"sm"} />
+          <StatEntry stat={player.stats.points} side="right" size={"sm"} />
         </>
       )}
     </>

--- a/src/components/StatEntry.tsx
+++ b/src/components/StatEntry.tsx
@@ -2,15 +2,19 @@ export default function StatEntry({
   stat,
   side,
   round = 0,
+  size = "lg",
 }: {
   stat: string | number | null | undefined;
   side: "left" | "center" | "right";
   round?: number;
+  size?: "sm" | "md" | "lg";
 }) {
   if (stat === null || stat === undefined) {
     return (
       <p
-        className={`text-${side} px-1 md:px-4 whitespace-nowrap border-1 border-gray-300`}
+        className={`text-${side} ${
+          size === "md" ? "w-10" : size === "sm" ? "w-10" : ""
+        }  whitespace-nowrap px-1 border-1 border-gray-300`}
       >
         N/A
       </p>
@@ -18,7 +22,9 @@ export default function StatEntry({
   }
   return (
     <p
-      className={`text-${side} px-1 md:px-4 whitespace-nowrap border-1 border-gray-300`}
+      className={`text-${side} ${
+        size === "md" ? "w-10" : size === "sm" ? "w-10" : ""
+      }  whitespace-nowrap px-1 border-1 border-gray-300`}
     >
       {typeof stat === "number" ? stat.toFixed(round) : stat}
     </p>

--- a/src/components/StatOutPutSizeButton.tsx
+++ b/src/components/StatOutPutSizeButton.tsx
@@ -12,23 +12,30 @@ export default function StatOutputSizeButton({
   return (
     <div className="flex flex-col relative">
       <button
-        onClick={() => {
+        onClick={(e) => {
+          e.stopPropagation();
           setLeagueSelectionVisible((prev) => !prev);
         }}
+        className={`  ${
+          leagueSelectionVisible ? "invisible" : " visible !border-slate-800"
+        }`}
       >
         {leagueSelection}
       </button>
-      <div className="absolute top-full -right-0 bg-gray-800 bg-opacity-50 z-10 flex items-center justify-center">
+      <div className="absolute  -left-0  z-10 flex items-center justify-center">
         {selectionOptions.map((option) => (
           <button
             key={option}
-            onClick={() => {
+            onClick={(e) => {
+              e.stopPropagation();
               setLeagueSelection(option as 10 | 25 | 50 | 100);
               setLeagueSelectionVisible(false);
             }}
-            className={`${
-              leagueSelection === option ? "bg-blue-500" : "bg-gray-300"
-            } p-2 m-1 ${leagueSelectionVisible ? "" : "hidden"}`}
+            className={` ${
+              leagueSelection === option
+                ? "!border-slate-200"
+                : "!border-slate-800"
+            } ${leagueSelectionVisible ? "" : "hidden"}`}
           >
             {option}
           </button>


### PR DESCRIPTION
Feat: League Stats Display in Dropdown Component

Moved league-wide stats for each position (skaters/goalies, forwards/defenseman/goalies) into a reusable dropdown component for improved layout clarity.
League stats are now hidden by default and can be toggled visible by the user.
Added smooth expand/collapse animation for dropdowns.
Updated tests to verify correct toggle behavior and CSS class application.
Ensured dropdown works on both mobile and desktop views.
This refactor keeps the UI cleaner and makes it easier to focus on core app functionality. The dropdown component can be reused elsewhere in the project.
Closes #1.