### PR TITLE
feat: add Simulate button

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,12 +4,17 @@ const tsJestTransformCfg = createDefaultPreset().transform;
 
 /** @type {import("jest").Config} **/
 export default {
-  testEnvironment: "jsdom", // <-- change this line
+  testEnvironment: "jsdom",
   transform: {
     ...tsJestTransformCfg,
   },
   moduleNameMapper: {
     "^@/(.*)$": "<rootDir>/src/$1",
+    "\\.(css|less|scss|sass)$": "<rootDir>/src/__tests__/src/styleMock.js",
   },
   setupFilesAfterEnv: ["<rootDir>/setupTests.ts"],
+  testMatch: [
+    "**/__tests__/**/*.(test|spec).(ts|tsx|js|jsx)",
+    "**/*.(test|spec).(ts|tsx|js|jsx)",
+  ],
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -347,8 +347,10 @@ function App() {
               />
             </StatsDropDown>
           </>
-          <YearInput />
-          <SimulateButton />
+          <div className="flex flex-1 flex-col sm:flex-row  justify-between items-top mt-4 gap-2 md:gap-6">
+            <YearInput />
+            <SimulateButton />
+          </div>
         </div>
       </div>
     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import StatsDropDown from "./components/DropDown";
 import type { Player } from "./types/player";
 import LeagueToggle from "./components/LeagueToggle";
 import YearInput from "./components/YearInput";
+import SimulateButton from "./components/SimulateButton";
 
 function App() {
   const [currentLeagueSelector, setCurrentLeagueSelector] = useState<
@@ -346,6 +347,7 @@ function App() {
             </StatsDropDown>
           </>
           <YearInput />
+          <SimulateButton />
         </div>
       </div>
     </div>

--- a/src/__tests__/src/components/SimulateButton.test.tsx
+++ b/src/__tests__/src/components/SimulateButton.test.tsx
@@ -1,0 +1,16 @@
+import SimulateButton from "@/components/SimulateButton";
+import { render, screen } from "@testing-library/react";
+
+describe("SimulateButton", () => {
+  test("renders button element", () => {
+    render(<SimulateButton />);
+    const button = screen.getByRole("button");
+    expect(button).toBeInTheDocument();
+  });
+
+  test("renders button text", () => {
+    render(<SimulateButton />);
+    const text = screen.getByText("SIMULATE ERA");
+    expect(text).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/src/styleMock.js
+++ b/src/__tests__/src/styleMock.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/src/components/SimulateButton.css
+++ b/src/components/SimulateButton.css
@@ -1,0 +1,94 @@
+.simulate-button {
+  overflow: hidden;
+  position: relative;
+  transform: translateZ(0); /* Enable hardware acceleration */
+  transition: all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+}
+
+.simulate-button:hover {
+  transform: translateY(-2px) scale(1.02);
+  box-shadow: 0 8px 25px rgba(0, 0, 0, 0.2);
+  border-color: #333;
+}
+
+.simulate-button:active {
+  transform: translateY(0) scale(0.98);
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.15);
+  transition: all 0.1s ease;
+}
+
+.simulate-button.disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none !important;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1) !important;
+}
+
+.gradient-overlay {
+  background: repeating-radial-gradient(
+    circle,
+    var(--darkGrey) 0%,
+    var(--lightGrey) 33%,
+    var(--darkGrey) 66%,
+    var(--white) 100%
+  );
+  background-size: 200% 200%;
+  background-position: 0% 0%;
+  height: 100%;
+  width: 100%;
+  transition: all 0.4s ease;
+  opacity: 0.8;
+}
+
+.simulate-button:hover .gradient-overlay {
+  background-position: 100% 100%;
+  background-size: 300% 300%;
+  opacity: 0.9;
+  animation: gradientShift 2s ease-in-out infinite;
+}
+
+.button-text {
+  transition: all 0.3s ease;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+}
+
+.simulate-button:hover .button-text {
+  transform: translateY(-1px);
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  letter-spacing: 0.5px;
+}
+
+@keyframes gradientShift {
+  0%,
+  100% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+}
+
+/* Add a subtle glow effect on hover */
+.simulate-button::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: linear-gradient(
+    45deg,
+    transparent,
+    rgba(255, 255, 255, 0.1),
+    transparent
+  );
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  pointer-events: none;
+  z-index: 5;
+}
+
+.simulate-button:hover::before {
+  opacity: 1;
+}

--- a/src/components/SimulateButton.tsx
+++ b/src/components/SimulateButton.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import "./SimulateButton.css";
 
 interface SimulateButtonProps {
@@ -8,27 +7,25 @@ interface SimulateButtonProps {
   className?: string;
 }
 
-const SimulateButton: React.FC<SimulateButtonProps> = ({
+export default function SimulateButton({
   text = "SIMULATE ERA",
   onClick,
   disabled = false,
   className = "",
-}) => {
+}: SimulateButtonProps) {
   return (
     <button
       className={`simulate-button ${className} ${
         disabled ? "disabled" : ""
-      } h-16 p-0! flex justify-center items-center relative overflow-hidden rounded-lg border-2 border-black bg-white cursor-pointer`}
+      } h-16 p-0! flex flex-1 justify-center items-center relative overflow-hidden rounded-lg border-3! border-black! bg-white cursor-pointer min-h-16`}
       onClick={onClick}
       disabled={disabled}
       type="button"
     >
       <div className="gradient-overlay absolute"></div>
       <span className="button-text text-center z-10 text-black font-black text-xl">
-        {text}
+        {disabled ? "Simulating..." : text}
       </span>
     </button>
   );
-};
-
-export default SimulateButton;
+}

--- a/src/components/SimulateButton.tsx
+++ b/src/components/SimulateButton.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import "./SimulateButton.css";
+
+interface SimulateButtonProps {
+  text?: string;
+  onClick?: () => void;
+  disabled?: boolean;
+  className?: string;
+}
+
+const SimulateButton: React.FC<SimulateButtonProps> = ({
+  text = "SIMULATE ERA",
+  onClick,
+  disabled = false,
+  className = "",
+}) => {
+  return (
+    <button
+      className={`simulate-button ${className} ${
+        disabled ? "disabled" : ""
+      } h-16 p-0! flex justify-center items-center relative overflow-hidden rounded-lg border-2 border-black bg-white cursor-pointer`}
+      onClick={onClick}
+      disabled={disabled}
+      type="button"
+    >
+      <div className="gradient-overlay absolute"></div>
+      <span className="button-text text-center z-10 text-black font-black text-xl">
+        {text}
+      </span>
+    </button>
+  );
+};
+
+export default SimulateButton;

--- a/src/index.css
+++ b/src/index.css
@@ -14,6 +14,11 @@
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   @apply text-xs sm:text-base md:text-lg lg:text-xl xl:text-2xl;
+
+  --black: #010101;
+  --white: #ffffff;
+  --lightGrey: #d0d3d4;
+  --darkGrey: #7c868e;
 }
 
 a {


### PR DESCRIPTION
Add prominent simulate era button to attract users to the section where they can simulate the league.

- Gradient style and large size draw attention to the button
- Button not functional, but setup for use.
- Tests made for whether button renders and has appropriate text
- test config changed to accommodate css
- add css variables for core colours

closes #21 