### PR TITLE
feat: add population data to league class and helper functions

### DIFF
--- a/src/__tests__/src/components/YearInput.test.tsx
+++ b/src/__tests__/src/components/YearInput.test.tsx
@@ -121,7 +121,7 @@ describe("YearInput", () => {
     const submitButton = screen.getByText("Set Year");
     fireEvent.change(input, { target: { value: " 2020 " } });
     fireEvent.click(submitButton);
-    expect(screen.getByTestId("year-value").textContent).toBe("2025");
+    expect(screen.getByTestId("year-value").textContent).toBe("2024");
   });
 
   test("Rounds down decimal values", () => {

--- a/src/context/League.tsx
+++ b/src/context/League.tsx
@@ -11,6 +11,9 @@ import {
   nationalitySorter,
   skaterSorter,
 } from "@/data/league/preSortedLeague";
+import getPopulationByYear, {
+  type populationEntry,
+} from "@/data/league/populationsByYear";
 
 type SimulationYearContextType = {
   year: number;
@@ -31,8 +34,9 @@ class League {
   sortedSkaters: ReturnType<typeof skaterSorter>;
   sortedGoalies: ReturnType<typeof goalieSorter>;
   leagueSortedByNationality: ReturnType<typeof nationalitySorter>;
+  populationNumbers: populationEntry[];
 
-  constructor(year = 2025) {
+  constructor(year = 2024) {
     this.forwards = leagueRoster.forwards;
     this.defensemen = leagueRoster.defensemen;
     this.goalies = leagueRoster.goalies;
@@ -48,6 +52,7 @@ class League {
       ...this.defensemen,
       ...this.goalies,
     ]);
+    this.populationNumbers = getPopulationByYear(this.year);
   }
 
   getPositionalRoster() {
@@ -67,14 +72,14 @@ class League {
 
 const SimulationYearContext = createContext<SimulationYearContextType>({
   league: undefined as unknown as League,
-  year: 2025,
+  year: 2024,
   setYear: () => {
     throw new Error("setYear must be used within a SimulationYearProvider");
   },
 });
 
 export function LeagueProvider({ children }: { children: React.ReactNode }) {
-  const [year, setYear] = useState(2025);
+  const [year, setYear] = useState(2024);
   // Re-instantiate league when year changes
   const league = new League(year);
   console.log("New league instantiated for year:", year);
@@ -85,4 +90,4 @@ export function LeagueProvider({ children }: { children: React.ReactNode }) {
   );
 }
 
-export { SimulationYearContext };
+export { SimulationYearContext, League };

--- a/src/data/league/populationsByYear.ts
+++ b/src/data/league/populationsByYear.ts
@@ -1,0 +1,65 @@
+import populationDataJson from "@/data/staticData/filtered_population.json";
+import growthRateDataJson from "@/data/staticData/growthrates.json";
+// Ensure populationData is of type populationDataType
+const populationData: populationDataType = populationDataJson;
+const growthRateData: growthRateDataType = growthRateDataJson;
+export type populationDataType = {
+  [key: string]: populationEntry[];
+};
+export type populationEntry = {
+  Country: string;
+  Population: number;
+};
+export type GrowthRateEntry = {
+  Country: string;
+  GrowthRate: number;
+};
+
+export type growthRateDataType = {
+  [key: string]: GrowthRateEntry[];
+};
+
+function formatYear(year: number): string {
+  const firstYearInRange = (year - 1).toString();
+  const yearString = year.toString().slice(-2);
+  return `${firstYearInRange}-${yearString}`;
+}
+export default function getPopulationByYear(
+  year: number
+): populationEntry[] | [] {
+  const formattedYear = formatYear(year);
+  if (year >= 1961) {
+    if (year >= 2024) {
+      // For 2024 and later, return the most recent available data (2023-24)
+      return populationData["2023-24"] || [];
+    }
+    // Cast populationData to populationDataType if necessary
+    return populationData[formattedYear] || [];
+    return populationData[formattedYear] || [];
+  } else {
+    const yearsFromLastData = 1961 - year;
+    // Adjust populations based on growth rates for years before 1961
+    const adjustedPopulations: populationEntry[] = [];
+    const lastAvailableData = populationData["1960-61"];
+    const growthRates = growthRateData["GrowthRates"];
+    if (lastAvailableData && growthRates) {
+      lastAvailableData.forEach((entry) => {
+        const growthRateEntry = growthRates.find(
+          (gr) => gr.Country === entry.Country
+        );
+        if (growthRateEntry) {
+          const adjustedPopulation = Math.round(
+            entry.Population /
+              Math.pow(1 + growthRateEntry.GrowthRate / 100, yearsFromLastData)
+          );
+          adjustedPopulations.push({
+            Country: entry.Country,
+            Population: adjustedPopulation,
+          });
+        }
+      });
+      return adjustedPopulations;
+    }
+  }
+  return [];
+}


### PR DESCRIPTION
- add population data functions for calculating data from year
- update league to store relevant population data
- use growth rate for dates before 1961
- use 2023-24 data for 2025 as data is unavailable
- add tests to make sure League is generating the data properly