### PR TITLE
feat: add nationality for simulation year function and property on the League object

### DIFF
--- a/src/__tests__/src/context/League.test.tsx
+++ b/src/__tests__/src/context/League.test.tsx
@@ -142,7 +142,7 @@ describe("League Context", () => {
       );
     });
 
-    test("provides nationality data for future year (2030) using most recent data", () => {
+    test("provides no data for future year (2030)", () => {
       render(<NationalityByYearTestComponent testYear={2030} />);
       const length = parseInt(
         screen

--- a/src/context/League.tsx
+++ b/src/context/League.tsx
@@ -55,7 +55,7 @@ class League {
       ...this.defensemen,
       ...this.goalies,
     ]);
-    this.currentPopulation = getPopulationByYear(2025); // added current population data
+    this.currentPopulation = getPopulationByYear(2025);
     this.populationNumbers = getPopulationByYear(this.year);
     this.nationalityOfLeague = getLeagueNationalityByYear(this.year);
   }

--- a/src/context/League.tsx
+++ b/src/context/League.tsx
@@ -14,6 +14,7 @@ import {
 import getPopulationByYear, {
   type populationEntry,
 } from "@/data/league/populationsByYear";
+import getLeagueNationalityByYear from "@/data/league/leagueNationaltyByYear";
 
 type SimulationYearContextType = {
   year: number;
@@ -36,6 +37,7 @@ class League {
   leagueSortedByNationality: ReturnType<typeof nationalitySorter>;
   currentPopulation: populationEntry[];
   populationNumbers: populationEntry[];
+  nationalityOfLeague: ReturnType<typeof getLeagueNationalityByYear>;
 
   constructor(year = 2024) {
     this.forwards = leagueRoster.forwards;
@@ -55,6 +57,7 @@ class League {
     ]);
     this.currentPopulation = getPopulationByYear(2025); // added current population data
     this.populationNumbers = getPopulationByYear(this.year);
+    this.nationalityOfLeague = getLeagueNationalityByYear(this.year);
   }
 
   getPositionalRoster() {
@@ -85,6 +88,7 @@ export function LeagueProvider({ children }: { children: React.ReactNode }) {
   // Re-instantiate league when year changes
   const league = new League(year);
   console.log("New league instantiated for year:", year);
+  console.log(league.nationalityOfLeague);
   return (
     <SimulationYearContext.Provider value={{ year, setYear, league }}>
       {children}

--- a/src/data/league/leagueNationaltyByYear.ts
+++ b/src/data/league/leagueNationaltyByYear.ts
@@ -1,0 +1,18 @@
+import nationalityDataJsonRaw from "@/data/staticData/nhl_nationality_grouped.json";
+import { formatYear } from "./populationsByYear";
+
+const nationalityDataJson: NationalityDataType =
+  nationalityDataJsonRaw as NationalityDataType;
+
+type NationalityDataType = {
+  [key: string]: NationalityEntry[];
+};
+type NationalityEntry = {
+  Nationality: string;
+  Players: number;
+};
+
+export default function getLeagueNationalityByYear(year: number) {
+  const formattedYear = formatYear(year);
+  return nationalityDataJson[formattedYear] ?? [];
+}

--- a/src/data/league/populationsByYear.ts
+++ b/src/data/league/populationsByYear.ts
@@ -19,7 +19,7 @@ export type growthRateDataType = {
   [key: string]: GrowthRateEntry[];
 };
 
-function formatYear(year: number): string {
+export function formatYear(year: number): string {
   const firstYearInRange = (year - 1).toString();
   const yearString = year.toString().slice(-2);
   return `${firstYearInRange}-${yearString}`;


### PR DESCRIPTION
- export format year from populationByYear
- create a function to extract relevant nationality data from source data
- add nationality data for year to League object
- add relevant tests
- clean up unnecessary comment