### PR TITLE
feat: add simulate league function build up a stripped down version of the league based on the year

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import "./App.css";
 import PlayerBar from "./components/PlayerBar";
 import StatPageNav from "./components/StatPageNav";
@@ -31,7 +31,6 @@ function App() {
   const [defensemenLeagueSelection, setDefensemenLeagueSelection] = useState<
     10 | 25 | 50 | 100
   >(10);
-
   // Roster and sort state
   const [skaterRoster, setSkaterRoster] = useState<Player[]>(
     league.sortedSkaters
@@ -49,6 +48,17 @@ function App() {
   const [goaliePage, setGoaliePage] = useState(1);
   const [forwardsPage, setForwardsPage] = useState(1);
   const [defensemenPage, setDefensemenPage] = useState(1);
+
+  useEffect(() => {
+    setSkaterRoster(league.sortedSkaters);
+    setGoalieRoster(league.sortedGoalies);
+    setForwardsRoster(league.sortedForwards);
+    setDefensemenRoster(league.sortedDefensemen);
+    setSkaterPage(1);
+    setGoaliePage(1);
+    setForwardsPage(1);
+    setDefensemenPage(1);
+  }, [league.sortedSkaters]);
 
   function handlePageChange(
     type: "skater" | "goalie" | "forwards" | "defensemen",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,7 +58,13 @@ function App() {
     setGoaliePage(1);
     setForwardsPage(1);
     setDefensemenPage(1);
-  }, [league.sortedSkaters]);
+  }, [
+    league.sortedSkaters,
+    league.sortedGoalies,
+    league.sortedForwards,
+    league.sortedDefensemen,
+    league.year,
+  ]);
 
   function handlePageChange(
     type: "skater" | "goalie" | "forwards" | "defensemen",

--- a/src/__tests__/src/context/League.test.tsx
+++ b/src/__tests__/src/context/League.test.tsx
@@ -1401,4 +1401,65 @@ describe("League Context", () => {
       expect(totalNationalities).toBeLessThan(50); // But reasonable number for NHL
     });
   });
+
+  describe("teamsFromYear property", () => {
+    it("should return an array of teams for a valid year", () => {
+      const league = new League(2024);
+      expect(Array.isArray(league.teamsFromYear)).toBe(true);
+      expect(league.teamsFromYear.length).toBeGreaterThan(0);
+    });
+
+    it("should return teams with correct structure", () => {
+      const league = new League(2024);
+      const teams = league.teamsFromYear;
+
+      if (teams.length > 0) {
+        teams.forEach((team) => {
+          expect(team).toHaveProperty("name");
+          expect(team).toHaveProperty("abbreviation");
+          expect(team).toHaveProperty("logo");
+          expect(typeof team.name).toBe("string");
+          expect(typeof team.abbreviation).toBe("string");
+          expect(typeof team.logo).toBe("string");
+        });
+      }
+    });
+
+    it("should return empty array for years outside valid boundaries", () => {
+      const yearTooEarly = new League(1917); // Before NHL founded
+      const yearTooLate = new League(2026); // Future year not in data
+
+      expect(yearTooEarly.teamsFromYear).toEqual([]);
+      expect(yearTooLate.teamsFromYear).toEqual([]);
+    });
+
+    it("should return different teams for different years", () => {
+      const league1918 = new League(1918); // First NHL season
+      const league2024 = new League(2024); // Recent season
+
+      expect(league1918.teamsFromYear).not.toEqual(league2024.teamsFromYear);
+      expect(league1918.teamsFromYear.length).toBeLessThan(
+        league2024.teamsFromYear.length
+      );
+    });
+
+    it("should return teams for the year specified in constructor", () => {
+      const testYear = 2023;
+      const league = new League(testYear);
+
+      expect(league.year).toBe(testYear);
+      // The teamsFromYear should correspond to the year passed to constructor
+      expect(Array.isArray(league.teamsFromYear)).toBe(true);
+    });
+
+    it("should handle edge case years within valid range", () => {
+      const firstYear = new League(1918); // First year in data
+      const lastYear = new League(2025); // Last year in data
+
+      expect(Array.isArray(firstYear.teamsFromYear)).toBe(true);
+      expect(Array.isArray(lastYear.teamsFromYear)).toBe(true);
+      expect(firstYear.teamsFromYear.length).toBeGreaterThan(0);
+      expect(lastYear.teamsFromYear.length).toBeGreaterThan(0);
+    });
+  });
 });

--- a/src/__tests__/src/context/League.test.tsx
+++ b/src/__tests__/src/context/League.test.tsx
@@ -258,56 +258,54 @@ describe("League Context", () => {
   });
 
   describe("League Data Access", () => {
-    test("provides correct forwards count", () => {
-      renderWithLeagueProvider();
-      expect(screen.getByTestId("forwards-count")).toHaveTextContent(
-        "Forwards count: 449"
-      );
-    });
-
-    test("provides correct defensemen count", () => {
-      renderWithLeagueProvider();
-      expect(screen.getByTestId("defensemen-count")).toHaveTextContent(
-        "Defensemen count: 253"
-      );
-    });
-
-    test("provides correct goalies count", () => {
-      renderWithLeagueProvider();
-      expect(screen.getByTestId("goalies-count")).toHaveTextContent(
-        "Goalies count: 73"
-      );
-    });
+    // test("provides correct forwards count", () => {
+    //   renderWithLeagueProvider();
+    //   expect(screen.getByTestId("forwards-count")).toHaveTextContent(
+    //     "Forwards count: 449"
+    //   );
+    // });
+    // test("provides correct defensemen count", () => {
+    //   renderWithLeagueProvider();
+    //   expect(screen.getByTestId("defensemen-count")).toHaveTextContent(
+    //     "Defensemen count: 253"
+    //   );
+    // });
+    // test("provides correct goalies count", () => {
+    //   renderWithLeagueProvider();
+    //   expect(screen.getByTestId("goalies-count")).toHaveTextContent(
+    //     "Goalies count: 73"
+    //   );
+    // });
   });
 
   describe("Sorted Data Functionality", () => {
-    test("provides sorted forwards with correct count", () => {
-      renderWithLeagueProvider();
-      expect(screen.getByTestId("sorted-forwards-count")).toHaveTextContent(
-        "Sorted forwards count: 449"
-      );
-    });
+    // test("provides sorted forwards with correct count", () => {
+    //   renderWithLeagueProvider();
+    //   expect(screen.getByTestId("sorted-forwards-count")).toHaveTextContent(
+    //     "Sorted forwards count: 449"
+    //   );
+    // });
 
-    test("provides sorted defensemen with correct count", () => {
-      renderWithLeagueProvider();
-      expect(screen.getByTestId("sorted-defensemen-count")).toHaveTextContent(
-        "Sorted defensemen count: 253"
-      );
-    });
+    // test("provides sorted defensemen with correct count", () => {
+    //   renderWithLeagueProvider();
+    //   expect(screen.getByTestId("sorted-defensemen-count")).toHaveTextContent(
+    //     "Sorted defensemen count: 253"
+    //   );
+    // });
 
-    test("provides sorted skaters combining forwards and defensemen", () => {
-      renderWithLeagueProvider();
-      expect(screen.getByTestId("sorted-skaters-count")).toHaveTextContent(
-        "Sorted skaters count: 702"
-      );
-    });
+    // test("provides sorted skaters combining forwards and defensemen", () => {
+    //   renderWithLeagueProvider();
+    //   expect(screen.getByTestId("sorted-skaters-count")).toHaveTextContent(
+    //     "Sorted skaters count: 702"
+    //   );
+    // });
 
-    test("provides sorted goalies with correct count", () => {
-      renderWithLeagueProvider();
-      expect(screen.getByTestId("sorted-goalies-count")).toHaveTextContent(
-        "Sorted goalies count: 73"
-      );
-    });
+    // test("provides sorted goalies with correct count", () => {
+    //   renderWithLeagueProvider();
+    //   expect(screen.getByTestId("sorted-goalies-count")).toHaveTextContent(
+    //     "Sorted goalies count: 73"
+    //   );
+    // });
 
     test("sorted forwards are ordered by points (top player has valid data)", () => {
       renderWithLeagueProvider();
@@ -562,26 +560,25 @@ describe("League Context", () => {
   });
 
   describe("League Methods", () => {
-    test("getPositionalRoster returns correct structure", () => {
-      renderWithLeagueProvider();
-      expect(
-        screen.getByTestId("positional-roster-forwards")
-      ).toHaveTextContent("Positional roster forwards: 449");
-    });
-
-    test("getFullRoster returns all position arrays", () => {
-      renderWithLeagueProvider();
-      // All counts should match the individual position counts
-      expect(screen.getByTestId("forwards-count")).toHaveTextContent(
-        "Forwards count: 449"
-      );
-      expect(screen.getByTestId("defensemen-count")).toHaveTextContent(
-        "Defensemen count: 253"
-      );
-      expect(screen.getByTestId("goalies-count")).toHaveTextContent(
-        "Goalies count: 73"
-      );
-    });
+    // test("getPositionalRoster returns correct structure", () => {
+    //   renderWithLeagueProvider();
+    //   expect(
+    //     screen.getByTestId("positional-roster-forwards")
+    //   ).toHaveTextContent("Positional roster forwards: 449");
+    // });
+    // test("getFullRoster returns all position arrays", () => {
+    //   renderWithLeagueProvider();
+    //   // All counts should match the individual position counts
+    //   expect(screen.getByTestId("forwards-count")).toHaveTextContent(
+    //     "Forwards count: 449"
+    //   );
+    //   expect(screen.getByTestId("defensemen-count")).toHaveTextContent(
+    //     "Defensemen count: 253"
+    //   );
+    //   expect(screen.getByTestId("goalies-count")).toHaveTextContent(
+    //     "Goalies count: 73"
+    //   );
+    // });
   });
 
   describe("Player Data Integrity", () => {
@@ -644,14 +641,6 @@ describe("League Context", () => {
       // Verify league was reinitialized with new year
       expect(screen.getByTestId("league-year")).toHaveTextContent(
         "League year: 2014"
-      );
-
-      // Data integrity should remain
-      expect(screen.getByTestId("forwards-count")).toHaveTextContent(
-        "Forwards count: 449"
-      );
-      expect(screen.getByTestId("sorted-skaters-count")).toHaveTextContent(
-        "Sorted skaters count: 702"
       );
     });
   });
@@ -1148,16 +1137,6 @@ describe("League Context", () => {
         </LeagueProvider>
       );
     };
-
-    test("nationality sorted array includes all players from all positions", () => {
-      renderNationalityTestComponent();
-
-      // Total should equal forwards + defensemen + goalies
-      const totalExpected = 449 + 253 + 73; // From earlier tests
-      expect(
-        screen.getByTestId("nationality-sorted-total-count")
-      ).toHaveTextContent(`Total nationality sorted players: ${totalExpected}`);
-    });
 
     test("nationality sorting is alphabetical", () => {
       renderNationalityTestComponent();

--- a/src/context/League.tsx
+++ b/src/context/League.tsx
@@ -16,6 +16,7 @@ import getPopulationByYear, {
 } from "@/data/league/populationsByYear";
 import getLeagueNationalityByYear from "@/data/league/leagueNationaltyByYear";
 import getTeamsByYear from "@/data/league/leagueTeamsByYear";
+import simulateLeague from "@/data/league/simulateLeague";
 
 type SimulationYearContextType = {
   year: number;
@@ -40,14 +41,29 @@ class League {
   populationNumbers: populationEntry[];
   nationalityOfLeague: ReturnType<typeof getLeagueNationalityByYear>;
   teamsFromYear: ReturnType<typeof getTeamsByYear>;
+  league: ReturnType<typeof simulateLeague>;
 
   constructor(year = 2024) {
-    this.forwards = leagueRoster.forwards;
-    this.defensemen = leagueRoster.defensemen;
-    this.goalies = leagueRoster.goalies;
-    this.initialLeague = leagueRoster;
-    this.currentLeague = leagueRoster;
     this.year = year;
+    this.currentPopulation = getPopulationByYear(2025);
+    this.populationNumbers = getPopulationByYear(this.year);
+    this.nationalityOfLeague = getLeagueNationalityByYear(this.year);
+    this.league = simulateLeague({
+      currentPopulations: this.currentPopulation,
+      simulatedPopulations: this.populationNumbers,
+      initialLeague: [
+        ...leagueRoster.forwards,
+        ...leagueRoster.defensemen,
+        ...leagueRoster.goalies,
+      ],
+      simulatedNationalityNumbers: this.nationalityOfLeague,
+    });
+    this.forwards = this.league.forwards;
+    this.defensemen = this.league.defensemen;
+    this.goalies = this.league.goalies;
+    this.initialLeague = leagueRoster;
+    this.currentLeague = this.league;
+
     this.sortedForwards = skaterSorter(this.forwards);
     this.sortedDefensemen = skaterSorter(this.defensemen);
     this.sortedSkaters = skaterSorter(this.forwards, this.defensemen);
@@ -57,9 +73,7 @@ class League {
       ...this.defensemen,
       ...this.goalies,
     ]);
-    this.currentPopulation = getPopulationByYear(2025);
-    this.populationNumbers = getPopulationByYear(this.year);
-    this.nationalityOfLeague = getLeagueNationalityByYear(this.year);
+
     this.teamsFromYear = getTeamsByYear(this.year);
   }
 
@@ -91,7 +105,7 @@ export function LeagueProvider({ children }: { children: React.ReactNode }) {
   // Re-instantiate league when year changes
   const league = new League(year);
   console.log("New league instantiated for year:", year);
-  console.log(league.teamsFromYear);
+  console.log(league.league);
   return (
     <SimulationYearContext.Provider value={{ year, setYear, league }}>
       {children}

--- a/src/context/League.tsx
+++ b/src/context/League.tsx
@@ -15,6 +15,7 @@ import getPopulationByYear, {
   type populationEntry,
 } from "@/data/league/populationsByYear";
 import getLeagueNationalityByYear from "@/data/league/leagueNationaltyByYear";
+import getTeamsByYear from "@/data/league/leagueTeamsByYear";
 
 type SimulationYearContextType = {
   year: number;
@@ -38,6 +39,7 @@ class League {
   currentPopulation: populationEntry[];
   populationNumbers: populationEntry[];
   nationalityOfLeague: ReturnType<typeof getLeagueNationalityByYear>;
+  teamsFromYear: ReturnType<typeof getTeamsByYear>;
 
   constructor(year = 2024) {
     this.forwards = leagueRoster.forwards;
@@ -58,6 +60,7 @@ class League {
     this.currentPopulation = getPopulationByYear(2025);
     this.populationNumbers = getPopulationByYear(this.year);
     this.nationalityOfLeague = getLeagueNationalityByYear(this.year);
+    this.teamsFromYear = getTeamsByYear(this.year);
   }
 
   getPositionalRoster() {
@@ -88,7 +91,7 @@ export function LeagueProvider({ children }: { children: React.ReactNode }) {
   // Re-instantiate league when year changes
   const league = new League(year);
   console.log("New league instantiated for year:", year);
-  console.log(league.nationalityOfLeague);
+  console.log(league.teamsFromYear);
   return (
     <SimulationYearContext.Provider value={{ year, setYear, league }}>
       {children}

--- a/src/context/League.tsx
+++ b/src/context/League.tsx
@@ -105,7 +105,7 @@ export function LeagueProvider({ children }: { children: React.ReactNode }) {
   // Re-instantiate league when year changes
   const league = new League(year);
   console.log("New league instantiated for year:", year);
-  console.log(league.league);
+  console.log(league);
   return (
     <SimulationYearContext.Provider value={{ year, setYear, league }}>
       {children}

--- a/src/data/handlers/filter_population_data.js
+++ b/src/data/handlers/filter_population_data.js
@@ -7,10 +7,10 @@ const relevantCountries = new Set([
   "Canada",
   "United States",
   "Sweden",
-  "Russia",
+  "Russian Federation", // Russia in CSV
   "Finland",
-  "Czech Republic",
-  "Slovakia",
+  "Czechia", // Czech Republic in CSV
+  "Slovak Republic", // Slovakia in CSV
   "Belarus",
   "Germany",
   "Austria",
@@ -27,11 +27,23 @@ const relevantCountries = new Set([
   "Croatia",
   "Netherlands",
   "Australia",
+  "United Kingdom",
+  "Uzbekistan",
 ]);
 
+// Map CSV country names to the names used in your NHL data
+const countryNameMapping = {
+  "Russian Federation": "Russia",
+  Czechia: "Czech Republic",
+  "Slovak Republic": "Slovakia",
+  // Add more mappings as needed
+};
+
 // Input and output file paths
-const inputCsvPath = path.join("population.csv");
-const outputJsonPath = path.join("filtered_population.json");
+const inputCsvPath = path.join("src/data/staticData/population.csv");
+const outputJsonPath = path.join(
+  "src/data/staticData/filtered_population.json"
+);
 
 const parseCsv = async () => {
   const fileStream = fs.createReadStream(inputCsvPath);
@@ -53,7 +65,12 @@ const parseCsv = async () => {
     const seasonKey = `${year}-${(year + 1).toString().slice(2)}`;
     if (!result[seasonKey]) result[seasonKey] = [];
 
-    result[seasonKey].push({ Country: country, Population: population });
+    // Use mapped name if available, otherwise use original name
+    const mappedCountryName = countryNameMapping[country] || country;
+    result[seasonKey].push({
+      Country: mappedCountryName,
+      Population: population,
+    });
   }
 
   fs.writeFileSync(outputJsonPath, JSON.stringify(result, null, 2));

--- a/src/data/league/leagueNationaltyByYear.ts
+++ b/src/data/league/leagueNationaltyByYear.ts
@@ -7,7 +7,7 @@ const nationalityDataJson: NationalityDataType =
 type NationalityDataType = {
   [key: string]: NationalityEntry[];
 };
-type NationalityEntry = {
+export type NationalityEntry = {
   Nationality: string;
   Players: number;
 };

--- a/src/data/league/leagueTeamsByYear.ts
+++ b/src/data/league/leagueTeamsByYear.ts
@@ -1,0 +1,21 @@
+import teamDataJsonRaw from "@/data/staticData/teams_by_year.json";
+
+const teamDataJson: TeamDataType = teamDataJsonRaw as TeamDataType;
+
+type TeamDataType = TeamItem[];
+
+type TeamItem = {
+  year: number;
+  teams: TeamEntry[];
+};
+
+type TeamEntry = {
+  name: string;
+  abbreviation: string;
+  logo: string;
+};
+
+export default function getTeamsByYear(year: number) {
+  const teams = teamDataJson.find((item) => item.year === year);
+  return teams ? teams.teams : [];
+}

--- a/src/data/league/simulateLeague.ts
+++ b/src/data/league/simulateLeague.ts
@@ -144,7 +144,6 @@ export default function simulateLeague({
     const goalies = goalieSorter(
       playersFromCountry.filter((player) => player.position === "G")
     );
-    let count = 0;
     let playerIdx = 0;
     let goalieIdx = 0;
     const playersBeingAdded = [];
@@ -152,12 +151,10 @@ export default function simulateLeague({
       if (playerIdx < players.length) {
         playersBeingAdded.push(players[playerIdx]);
         playerIdx++;
-        count++;
       }
       if (goalieIdx < goalies.length) {
         playersBeingAdded.push(goalies[goalieIdx]);
         goalieIdx++;
-        count++;
       }
       if (goalieIdx >= goalies.length) {
         playersBeingAdded.push(

--- a/src/data/league/simulateLeague.ts
+++ b/src/data/league/simulateLeague.ts
@@ -1,0 +1,203 @@
+import type { Player } from "@/types/player";
+import type { populationEntry } from "./populationsByYear";
+import type { NationalityEntry } from "./leagueNationaltyByYear";
+import { goalieSorter, skaterSorter } from "./preSortedLeague";
+
+// All unique country abbreviations from nhl_player_stats_2024_2025.json
+export const NHL_COUNTRY_ABBREVIATIONS = [
+  "CAN",
+  "USA",
+  "SWE",
+  "FIN",
+  "RUS",
+  "CZE",
+  "CHE",
+  "SVK",
+  "DEU",
+  "NOR",
+  "LVA",
+  "BLR",
+  "AUS",
+  "GBR",
+  "UZB",
+  "AUT",
+  "FRA",
+  "DNK",
+  "SVN",
+];
+
+// Mapping of country abbreviations to full country names (formatted as in nhl_nationality_data.json)
+export const NHL_COUNTRY_NAMES: { [abbr: string]: string } = {
+  CAN: "Canada",
+  USA: "United States",
+  SWE: "Sweden",
+  FIN: "Finland",
+  RUS: "Russia",
+  CZE: "Czech Republic",
+  CHE: "Switzerland",
+  SVK: "Slovakia",
+  DEU: "Germany",
+  NOR: "Norway",
+  LVA: "Latvia",
+  BLR: "Belarus",
+  AUS: "Australia",
+  GBR: "United Kingdom",
+  UZB: "Uzbekistan",
+  AUT: "Austria",
+  FRA: "France",
+  DNK: "Denmark",
+  SVN: "Slovenia",
+};
+
+type shrinkRatesType = {
+  [key: string]: number;
+};
+
+export default function simulateLeague({
+  currentPopulations,
+  simulatedPopulations,
+  initialLeague,
+  simulatedNationalityNumbers,
+}: {
+  currentPopulations: populationEntry[];
+  simulatedPopulations: populationEntry[];
+  initialLeague: Player[];
+  simulatedNationalityNumbers: NationalityEntry[];
+}) {
+  // Calculate shrink rates based on population changes and add to new object shrinkRates
+  const shrinkRates = {} as shrinkRatesType;
+  simulatedPopulations.map((simulatedPopulation) => {
+    const currentPopulation = currentPopulations.find(
+      (Country) => Country.Country === simulatedPopulation.Country
+    );
+    if (!currentPopulation) {
+      console.error(
+        "Error finding current population for country:",
+        simulatedPopulation.Country
+      );
+      return initialLeague;
+    }
+    const shrinkRate =
+      simulatedPopulation.Population / currentPopulation.Population;
+    shrinkRates[simulatedPopulation.Country] =
+      shrinkRate <= 0.95 ? shrinkRate : 1;
+  });
+  // Now apply shrink rates to initial league to create simulated league. Players are removed randomly based on shrink rate.
+  const thanosSnapped = { league: [] } as { league: Player[] };
+  Object.entries(shrinkRates).map(([country, rate]) => {
+    const playersFromCountry = initialLeague.filter(
+      (player) => NHL_COUNTRY_NAMES[player.nationality] === country
+    );
+    if (playersFromCountry.length === 0) return;
+    const numberToRemove = Math.floor(playersFromCountry.length * (1 - rate));
+    const shuffledPlayers = playersFromCountry.sort(() => 0.5 - Math.random());
+    const playersToKeep = shuffledPlayers.slice(
+      numberToRemove,
+      playersFromCountry.length
+    );
+    thanosSnapped.league.push(...playersToKeep);
+  });
+  debugger;
+
+  // Players from countries not in shrinkRates are not included in the simulated league, so they are ignored.
+  // Ensure the simulated league has the correct number of players from each country based on simulatedNationalityNumbers.
+  const finalLeague = [] as Player[];
+  let remainingPlayers = 0;
+  let numberNeeded = 0;
+  simulatedNationalityNumbers.forEach((nationality) => {
+    const country = nationality.Nationality;
+    const playersFromCountry = thanosSnapped.league.filter(
+      (player) => NHL_COUNTRY_NAMES[player.nationality] === country
+    );
+    numberNeeded += nationality.Players as number;
+    if (playersFromCountry.length <= numberNeeded) {
+      finalLeague.push(...playersFromCountry);
+      remainingPlayers = numberNeeded - playersFromCountry.length;
+    } else {
+      const players = skaterSorter(
+        playersFromCountry.filter((player) => player.position !== "G")
+      );
+      const goalies = goalieSorter(
+        playersFromCountry.filter((player) => player.position === "G")
+      );
+      let count = 0;
+      let playerIdx = 0;
+      let goalieIdx = 0;
+      const playersBeingAdded = [];
+      while (
+        count < numberNeeded &&
+        (count < players.length || count < goalies.length)
+      ) {
+        if (playerIdx < players.length) {
+          playersBeingAdded.push(players[playerIdx]);
+          playerIdx++;
+          count++;
+        }
+        if (goalieIdx < goalies.length) {
+          playersBeingAdded.push(goalies[goalieIdx]);
+          goalieIdx++;
+          count++;
+        }
+        if (goalieIdx >= goalies.length) {
+          playersBeingAdded.push(
+            ...players.slice(playersBeingAdded.length, numberNeeded)
+          );
+          break;
+        }
+        if (playerIdx >= players.length) {
+          playersBeingAdded.push(
+            ...goalies.slice(playersBeingAdded.length, numberNeeded)
+          );
+          break;
+        }
+        if (count >= numberNeeded) {
+          break;
+        }
+      }
+      if (playersBeingAdded.length > numberNeeded) {
+        finalLeague.push(...playersBeingAdded.slice(0, numberNeeded));
+      } else {
+        finalLeague.push(...playersBeingAdded);
+      }
+    }
+    if (remainingPlayers && remainingPlayers > 0) {
+      const remainingCanadians = thanosSnapped.league.filter(
+        (player) =>
+          player.nationality === "Canada" && !finalLeague.includes(player)
+      );
+      const playersBeingAdded = skaterSorter(remainingCanadians).slice(
+        0,
+        remainingPlayers
+      );
+      finalLeague.push(...playersBeingAdded);
+      remainingPlayers -= playersBeingAdded.length;
+      const placeHolderPlayer = {
+        playerId: Number(Math.floor(Math.random() * 100 * 100000)),
+        headshot: "empty",
+        firstName: "Other Professional",
+        lastName: "Player",
+        position: "C",
+        nationality: "CAN",
+        fgq: "forward",
+        stats: {
+          gamesPlayed: 1,
+          goals: 0,
+          assists: 0,
+          points: 0,
+        },
+      };
+      while (remainingPlayers > 0) {
+        finalLeague.push(placeHolderPlayer);
+        remainingPlayers--;
+      }
+    }
+  });
+  return divideLeagueByPosition(finalLeague);
+}
+
+function divideLeagueByPosition(league: Player[]) {
+  const forwards = league.filter((player) => player.fgq === "forward");
+  const defensemen = league.filter((player) => player.fgq === "defenseman");
+  const goalies = league.filter((player) => player.position === "goalie");
+  return { forwards, defensemen, goalies };
+}

--- a/src/data/staticData/filtered_population.json
+++ b/src/data/staticData/filtered_population.json
@@ -21,6 +21,10 @@
       "Population": 5327827
     },
     {
+      "Country": "Czech Republic",
+      "Population": 9602006
+    },
+    {
       "Country": "Germany",
       "Population": 72814900
     },
@@ -35,6 +39,10 @@
     {
       "Country": "France",
       "Population": 47412964
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 52400000
     },
     {
       "Country": "Croatia",
@@ -61,6 +69,14 @@
       "Population": 3581239
     },
     {
+      "Country": "Russia",
+      "Population": 119897000
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 4068095
+    },
+    {
       "Country": "Slovenia",
       "Population": 1584720
     },
@@ -75,6 +91,10 @@
     {
       "Country": "United States",
       "Population": 180671000
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 8209109
     }
   ],
   "1961-62": [
@@ -99,6 +119,10 @@
       "Population": 5434294
     },
     {
+      "Country": "Czech Republic",
+      "Population": 9586651
+    },
+    {
       "Country": "Germany",
       "Population": 73377632
     },
@@ -113,6 +137,10 @@
     {
       "Country": "France",
       "Population": 47905982
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 52800000
     },
     {
       "Country": "Croatia",
@@ -139,6 +167,14 @@
       "Population": 3609800
     },
     {
+      "Country": "Russia",
+      "Population": 121236000
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 4191667
+    },
+    {
       "Country": "Slovenia",
       "Population": 1594131
     },
@@ -153,6 +189,10 @@
     {
       "Country": "United States",
       "Population": 183691000
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 8517711
     }
   ],
   "1962-63": [
@@ -177,6 +217,10 @@
       "Population": 5573815
     },
     {
+      "Country": "Czech Republic",
+      "Population": 9624660
+    },
+    {
       "Country": "Germany",
       "Population": 74025784
     },
@@ -191,6 +235,10 @@
     {
       "Country": "France",
       "Population": 48389516
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 53250000
     },
     {
       "Country": "Croatia",
@@ -217,6 +265,14 @@
       "Population": 3638918
     },
     {
+      "Country": "Russia",
+      "Population": 122591000
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 4238188
+    },
+    {
       "Country": "Slovenia",
       "Population": 1603649
     },
@@ -231,6 +287,10 @@
     {
       "Country": "United States",
       "Population": 186538000
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 8854368
     }
   ],
   "1963-64": [
@@ -255,6 +315,10 @@
       "Population": 5694247
     },
     {
+      "Country": "Czech Republic",
+      "Population": 9670685
+    },
+    {
       "Country": "Germany",
       "Population": 74714353
     },
@@ -269,6 +333,10 @@
     {
       "Country": "France",
       "Population": 48877567
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 53650000
     },
     {
       "Country": "Croatia",
@@ -295,6 +363,14 @@
       "Population": 3666537
     },
     {
+      "Country": "Russia",
+      "Population": 123960000
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 4282017
+    },
+    {
       "Country": "Slovenia",
       "Population": 1616971
     },
@@ -309,6 +385,10 @@
     {
       "Country": "United States",
       "Population": 189242000
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 9202246
     }
   ],
   "1964-65": [
@@ -333,6 +413,10 @@
       "Population": 5789228
     },
     {
+      "Country": "Czech Republic",
+      "Population": 9727804
+    },
+    {
       "Country": "Germany",
       "Population": 75318337
     },
@@ -347,6 +431,10 @@
     {
       "Country": "France",
       "Population": 49401492
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 54000000
     },
     {
       "Country": "Croatia",
@@ -373,6 +461,14 @@
       "Population": 3694339
     },
     {
+      "Country": "Russia",
+      "Population": 125345000
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 4327341
+    },
+    {
       "Country": "Slovenia",
       "Population": 1632114
     },
@@ -387,6 +483,10 @@
     {
       "Country": "United States",
       "Population": 191889000
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 9557611
     }
   ],
   "1965-66": [
@@ -411,6 +511,10 @@
       "Population": 5856472
     },
     {
+      "Country": "Czech Republic",
+      "Population": 9779358
+    },
+    {
       "Country": "Germany",
       "Population": 75963695
     },
@@ -425,6 +529,10 @@
     {
       "Country": "France",
       "Population": 49877725
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 54348050
     },
     {
       "Country": "Croatia",
@@ -451,6 +559,14 @@
       "Population": 3723168
     },
     {
+      "Country": "Russia",
+      "Population": 126745000
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 4370983
+    },
+    {
       "Country": "Slovenia",
       "Population": 1649160
     },
@@ -465,6 +581,10 @@
     {
       "Country": "United States",
       "Population": 194303000
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 9921681
     }
   ],
   "1966-67": [
@@ -489,6 +609,10 @@
       "Population": 5918002
     },
     {
+      "Country": "Czech Republic",
+      "Population": 9821040
+    },
+    {
       "Country": "Germany",
       "Population": 76600311
     },
@@ -503,6 +627,10 @@
     {
       "Country": "France",
       "Population": 50311637
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 54648500
     },
     {
       "Country": "Croatia",
@@ -529,6 +657,14 @@
       "Population": 3753012
     },
     {
+      "Country": "Russia",
+      "Population": 127468000
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 4411666
+    },
+    {
       "Country": "Slovenia",
       "Population": 1669905
     },
@@ -543,6 +679,10 @@
     {
       "Country": "United States",
       "Population": 196560000
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 10289294
     }
   ],
   "1967-68": [
@@ -567,6 +707,10 @@
       "Population": 5991785
     },
     {
+      "Country": "Czech Republic",
+      "Population": 9852899
+    },
+    {
       "Country": "Germany",
       "Population": 76951336
     },
@@ -581,6 +725,10 @@
     {
       "Country": "France",
       "Population": 50722791
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 54943600
     },
     {
       "Country": "Croatia",
@@ -607,6 +755,14 @@
       "Population": 3784539
     },
     {
+      "Country": "Russia",
+      "Population": 128196000
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 4449367
+    },
+    {
       "Country": "Slovenia",
       "Population": 1689528
     },
@@ -621,6 +777,10 @@
     {
       "Country": "United States",
       "Population": 198712000
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 10659180
     }
   ],
   "1968-69": [
@@ -645,6 +805,10 @@
       "Population": 6067714
     },
     {
+      "Country": "Czech Republic",
+      "Population": 9876346
+    },
+    {
       "Country": "Germany",
       "Population": 77294314
     },
@@ -659,6 +823,10 @@
     {
       "Country": "France",
       "Population": 51112980
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 55211700
     },
     {
       "Country": "Croatia",
@@ -685,6 +853,14 @@
       "Population": 3816486
     },
     {
+      "Country": "Russia",
+      "Population": 128928000
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 4483915
+    },
+    {
       "Country": "Slovenia",
       "Population": 1704546
     },
@@ -699,6 +875,10 @@
     {
       "Country": "United States",
       "Population": 200706000
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 11032155
     }
   ],
   "1969-70": [
@@ -723,6 +903,10 @@
       "Population": 6136387
     },
     {
+      "Country": "Czech Republic",
+      "Population": 9896580
+    },
+    {
       "Country": "Germany",
       "Population": 77909682
     },
@@ -737,6 +921,10 @@
     {
       "Country": "France",
       "Population": 51536014
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 55441750
     },
     {
       "Country": "Croatia",
@@ -763,6 +951,14 @@
       "Population": 3847707
     },
     {
+      "Country": "Russia",
+      "Population": 129664000
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 4518607
+    },
+    {
       "Country": "Slovenia",
       "Population": 1713874
     },
@@ -777,6 +973,10 @@
     {
       "Country": "United States",
       "Population": 202677000
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 11403150
     }
   ],
   "1970-71": [
@@ -801,6 +1001,10 @@
       "Population": 6180877
     },
     {
+      "Country": "Czech Republic",
+      "Population": 9858071
+    },
+    {
       "Country": "Germany",
       "Population": 78169289
     },
@@ -815,6 +1019,10 @@
     {
       "Country": "France",
       "Population": 52007169
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 55663250
     },
     {
       "Country": "Croatia",
@@ -841,6 +1049,14 @@
       "Population": 3875763
     },
     {
+      "Country": "Russia",
+      "Population": 130404000
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 4538223
+    },
+    {
       "Country": "Slovenia",
       "Population": 1724891
     },
@@ -855,6 +1071,10 @@
     {
       "Country": "United States",
       "Population": 205052000
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 11762638
     }
   ],
   "1971-72": [
@@ -879,6 +1099,10 @@
       "Population": 6213399
     },
     {
+      "Country": "Czech Republic",
+      "Population": 9826815
+    },
+    {
       "Country": "Germany",
       "Population": 78312842
     },
@@ -893,6 +1117,10 @@
     {
       "Country": "France",
       "Population": 52499553
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 55896223
     },
     {
       "Country": "Croatia",
@@ -919,6 +1147,14 @@
       "Population": 3903039
     },
     {
+      "Country": "Russia",
+      "Population": 131155000
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 4557449
+    },
+    {
       "Country": "Slovenia",
       "Population": 1738335
     },
@@ -933,6 +1169,10 @@
     {
       "Country": "United States",
       "Population": 207661000
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 12111511
     }
   ],
   "1972-73": [
@@ -957,6 +1197,10 @@
       "Population": 6260956
     },
     {
+      "Country": "Czech Republic",
+      "Population": 9867632
+    },
+    {
       "Country": "Germany",
       "Population": 78688452
     },
@@ -971,6 +1215,10 @@
     {
       "Country": "France",
       "Population": 52962356
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 56086065
     },
     {
       "Country": "Croatia",
@@ -997,6 +1245,14 @@
       "Population": 3933004
     },
     {
+      "Country": "Russia",
+      "Population": 131909000
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 4596622
+    },
+    {
       "Country": "Slovenia",
       "Population": 1752233
     },
@@ -1011,6 +1267,10 @@
     {
       "Country": "United States",
       "Population": 209896000
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 12465106
     }
   ],
   "1973-74": [
@@ -1035,6 +1295,10 @@
       "Population": 6307347
     },
     {
+      "Country": "Czech Republic",
+      "Population": 9922266
+    },
+    {
       "Country": "Germany",
       "Population": 78936666
     },
@@ -1049,6 +1313,10 @@
     {
       "Country": "France",
       "Population": 53392161
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 56194527
     },
     {
       "Country": "Croatia",
@@ -1075,6 +1343,14 @@
       "Population": 3960612
     },
     {
+      "Country": "Russia",
+      "Population": 132669000
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 4641445
+    },
+    {
       "Country": "Slovenia",
       "Population": 1766697
     },
@@ -1089,6 +1365,10 @@
     {
       "Country": "United States",
       "Population": 211909000
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 12831047
     }
   ],
   "1974-75": [
@@ -1113,6 +1393,10 @@
       "Population": 6341405
     },
     {
+      "Country": "Czech Republic",
+      "Population": 9988459
+    },
+    {
       "Country": "Germany",
       "Population": 78967433
     },
@@ -1127,6 +1411,10 @@
     {
       "Country": "France",
       "Population": 53746571
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 56229974
     },
     {
       "Country": "Croatia",
@@ -1153,6 +1441,14 @@
       "Population": 3985258
     },
     {
+      "Country": "Russia",
+      "Population": 133432000
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 4689623
+    },
+    {
       "Country": "Slovenia",
       "Population": 1776132
     },
@@ -1167,6 +1463,10 @@
     {
       "Country": "United States",
       "Population": 213854000
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 13209011
     }
   ],
   "1975-76": [
@@ -1191,6 +1491,10 @@
       "Population": 6338632
     },
     {
+      "Country": "Czech Republic",
+      "Population": 10058620
+    },
+    {
       "Country": "Germany",
       "Population": 78673554
     },
@@ -1205,6 +1509,10 @@
     {
       "Country": "France",
       "Population": 54002853
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 56225800
     },
     {
       "Country": "Croatia",
@@ -1231,6 +1539,14 @@
       "Population": 4007313
     },
     {
+      "Country": "Russia",
+      "Population": 134200000
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 4739105
+    },
+    {
       "Country": "Slovenia",
       "Population": 1793581
     },
@@ -1245,6 +1561,10 @@
     {
       "Country": "United States",
       "Population": 215973000
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 13598521
     }
   ],
   "1976-77": [
@@ -1269,6 +1589,10 @@
       "Population": 6302504
     },
     {
+      "Country": "Czech Republic",
+      "Population": 10125939
+    },
+    {
       "Country": "Germany",
       "Population": 78336950
     },
@@ -1283,6 +1607,10 @@
     {
       "Country": "France",
       "Population": 54232383
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 56211968
     },
     {
       "Country": "Croatia",
@@ -1309,6 +1637,14 @@
       "Population": 4026152
     },
     {
+      "Country": "Russia",
+      "Population": 135147000
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 4789507
+    },
+    {
       "Country": "Slovenia",
       "Population": 1820249
     },
@@ -1323,6 +1659,10 @@
     {
       "Country": "United States",
       "Population": 218035000
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 13998620
     }
   ],
   "1977-78": [
@@ -1347,6 +1687,10 @@
       "Population": 6281174
     },
     {
+      "Country": "Czech Republic",
+      "Population": 10186755
+    },
+    {
       "Country": "Germany",
       "Population": 78159814
     },
@@ -1361,6 +1705,10 @@
     {
       "Country": "France",
       "Population": 54486467
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 56193492
     },
     {
       "Country": "Croatia",
@@ -1387,6 +1735,14 @@
       "Population": 4043205
     },
     {
+      "Country": "Russia",
+      "Population": 136100000
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 4840501
+    },
+    {
       "Country": "Slovenia",
       "Population": 1842377
     },
@@ -1401,6 +1757,10 @@
     {
       "Country": "United States",
       "Population": 220239000
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 14408822
     }
   ],
   "1978-79": [
@@ -1425,6 +1785,10 @@
       "Population": 6281738
     },
     {
+      "Country": "Czech Republic",
+      "Population": 10242098
+    },
+    {
       "Country": "Germany",
       "Population": 78091820
     },
@@ -1439,6 +1803,10 @@
     {
       "Country": "France",
       "Population": 54734030
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 56196504
     },
     {
       "Country": "Croatia",
@@ -1465,6 +1833,14 @@
       "Population": 4058671
     },
     {
+      "Country": "Russia",
+      "Population": 137060000
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 4890125
+    },
+    {
       "Country": "Slovenia",
       "Population": 1862548
     },
@@ -1479,6 +1855,10 @@
     {
       "Country": "United States",
       "Population": 222585000
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 14816349
     }
   ],
   "1979-80": [
@@ -1503,6 +1883,10 @@
       "Population": 6294365
     },
     {
+      "Country": "Czech Republic",
+      "Population": 10292341
+    },
+    {
       "Country": "Germany",
       "Population": 78126350
     },
@@ -1517,6 +1901,10 @@
     {
       "Country": "France",
       "Population": 54979851
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 56246951
     },
     {
       "Country": "Croatia",
@@ -1543,6 +1931,14 @@
       "Population": 4072517
     },
     {
+      "Country": "Russia",
+      "Population": 138027000
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 4938973
+    },
+    {
       "Country": "Slovenia",
       "Population": 1882599
     },
@@ -1557,6 +1953,10 @@
     {
       "Country": "United States",
       "Population": 225055000
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 15215587
     }
   ],
   "1980-81": [
@@ -1581,6 +1981,10 @@
       "Population": 6319408
     },
     {
+      "Country": "Czech Republic",
+      "Population": 10304193
+    },
+    {
       "Country": "Germany",
       "Population": 78288576
     },
@@ -1595,6 +1999,10 @@
     {
       "Country": "France",
       "Population": 55274184
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 56314216
     },
     {
       "Country": "Croatia",
@@ -1621,6 +2029,14 @@
       "Population": 4085620
     },
     {
+      "Country": "Russia",
+      "Population": 139010000
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 4979815
+    },
+    {
       "Country": "Slovenia",
       "Population": 1901315
     },
@@ -1635,6 +2051,10 @@
     {
       "Country": "United States",
       "Population": 227225000
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 15619936
     }
   ],
   "1981-82": [
@@ -1659,6 +2079,10 @@
       "Population": 6354074
     },
     {
+      "Country": "Czech Republic",
+      "Population": 10300591
+    },
+    {
       "Country": "Germany",
       "Population": 78407907
     },
@@ -1673,6 +2097,10 @@
     {
       "Country": "France",
       "Population": 55603353
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 56333829
     },
     {
       "Country": "Croatia",
@@ -1699,6 +2127,14 @@
       "Population": 4099702
     },
     {
+      "Country": "Russia",
+      "Population": 139941000
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 5016105
+    },
+    {
       "Country": "Slovenia",
       "Population": 1906531
     },
@@ -1713,6 +2149,10 @@
     {
       "Country": "United States",
       "Population": 229466000
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 16035032
     }
   ],
   "1982-83": [
@@ -1737,6 +2177,10 @@
       "Population": 6391309
     },
     {
+      "Country": "Czech Republic",
+      "Population": 10314826
+    },
+    {
       "Country": "Germany",
       "Population": 78333366
     },
@@ -1751,6 +2195,10 @@
     {
       "Country": "France",
       "Population": 55806789
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 56313641
     },
     {
       "Country": "Croatia",
@@ -1777,6 +2225,14 @@
       "Population": 4114787
     },
     {
+      "Country": "Russia",
+      "Population": 140823000
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 5055099
+    },
+    {
       "Country": "Slovenia",
       "Population": 1910334
     },
@@ -1791,6 +2247,10 @@
     {
       "Country": "United States",
       "Population": 231664000
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 16462736
     }
   ],
   "1983-84": [
@@ -1815,6 +2275,10 @@
       "Population": 6418773
     },
     {
+      "Country": "Czech Republic",
+      "Population": 10323856
+    },
+    {
       "Country": "Germany",
       "Population": 78128282
     },
@@ -1829,6 +2293,10 @@
     {
       "Country": "France",
       "Population": 56108330
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 56332848
     },
     {
       "Country": "Croatia",
@@ -1855,6 +2323,14 @@
       "Population": 4128432
     },
     {
+      "Country": "Russia",
+      "Population": 141668000
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 5091971
+    },
+    {
       "Country": "Slovenia",
       "Population": 1922321
     },
@@ -1869,6 +2345,10 @@
     {
       "Country": "United States",
       "Population": 233792000
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 16908400
     }
   ],
   "1984-85": [
@@ -1893,6 +2373,10 @@
       "Population": 6441865
     },
     {
+      "Country": "Czech Republic",
+      "Population": 10330213
+    },
+    {
       "Country": "Germany",
       "Population": 77858685
     },
@@ -1907,6 +2391,10 @@
     {
       "Country": "France",
       "Population": 56383085
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 56422072
     },
     {
       "Country": "Croatia",
@@ -1933,6 +2421,14 @@
       "Population": 4140099
     },
     {
+      "Country": "Russia",
+      "Population": 142745000
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 5127097
+    },
+    {
       "Country": "Slovenia",
       "Population": 1932154
     },
@@ -1947,6 +2443,10 @@
     {
       "Country": "United States",
       "Population": 235825000
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 17378846
     }
   ],
   "1985-86": [
@@ -1971,6 +2471,10 @@
       "Population": 6470365
     },
     {
+      "Country": "Czech Republic",
+      "Population": 10337118
+    },
+    {
       "Country": "Germany",
       "Population": 77684873
     },
@@ -1985,6 +2489,10 @@
     {
       "Country": "France",
       "Population": 56665619
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 56550268
     },
     {
       "Country": "Croatia",
@@ -2011,6 +2519,14 @@
       "Population": 4152516
     },
     {
+      "Country": "Russia",
+      "Population": 143858000
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 5161768
+    },
+    {
       "Country": "Slovenia",
       "Population": 1941641
     },
@@ -2025,6 +2541,10 @@
     {
       "Country": "United States",
       "Population": 237924000
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 17875339
     }
   ],
   "1986-87": [
@@ -2049,6 +2569,10 @@
       "Population": 6504124
     },
     {
+      "Country": "Czech Republic",
+      "Population": 10342227
+    },
+    {
       "Country": "Germany",
       "Population": 77720436
     },
@@ -2063,6 +2587,10 @@
     {
       "Country": "France",
       "Population": 56956002
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 56681396
     },
     {
       "Country": "Croatia",
@@ -2089,6 +2617,14 @@
       "Population": 4167354
     },
     {
+      "Country": "Russia",
+      "Population": 144894000
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 5193838
+    },
+    {
       "Country": "Slovenia",
       "Population": 1965964
     },
@@ -2103,6 +2639,10 @@
     {
       "Country": "United States",
       "Population": 240133000
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 18395621
     }
   ],
   "1987-88": [
@@ -2127,6 +2667,10 @@
       "Population": 6545106
     },
     {
+      "Country": "Czech Republic",
+      "Population": 10347318
+    },
+    {
       "Country": "Germany",
       "Population": 77839920
     },
@@ -2141,6 +2685,10 @@
     {
       "Country": "France",
       "Population": 57266167
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 56802050
     },
     {
       "Country": "Croatia",
@@ -2167,6 +2715,14 @@
       "Population": 4186905
     },
     {
+      "Country": "Russia",
+      "Population": 145908000
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 5222840
+    },
+    {
       "Country": "Slovenia",
       "Population": 1989776
     },
@@ -2181,6 +2737,10 @@
     {
       "Country": "United States",
       "Population": 242289000
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 18930070
     }
   ],
   "1988-89": [
@@ -2205,6 +2765,10 @@
       "Population": 6593386
     },
     {
+      "Country": "Czech Republic",
+      "Population": 10355276
+    },
+    {
       "Country": "Germany",
       "Population": 78144619
     },
@@ -2219,6 +2783,10 @@
     {
       "Country": "France",
       "Population": 57598186
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 56928327
     },
     {
       "Country": "Croatia",
@@ -2245,6 +2813,14 @@
       "Population": 4209488
     },
     {
+      "Country": "Russia",
+      "Population": 146857000
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 5250596
+    },
+    {
       "Country": "Slovenia",
       "Population": 1995196
     },
@@ -2259,6 +2835,10 @@
     {
       "Country": "United States",
       "Population": 244499000
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 19460630
     }
   ],
   "1989-90": [
@@ -2283,6 +2863,10 @@
       "Population": 6646912
     },
     {
+      "Country": "Czech Republic",
+      "Population": 10361068
+    },
+    {
       "Country": "Germany",
       "Population": 78751283
     },
@@ -2297,6 +2881,10 @@
     {
       "Country": "France",
       "Population": 57943062
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 57076711
     },
     {
       "Country": "Croatia",
@@ -2323,6 +2911,14 @@
       "Population": 4226901
     },
     {
+      "Country": "Russia",
+      "Population": 147721000
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 5275942
+    },
+    {
       "Country": "Slovenia",
       "Population": 1996351
     },
@@ -2337,6 +2933,10 @@
     {
       "Country": "United States",
       "Population": 246819000
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 19977183
     }
   ],
   "1990-91": [
@@ -2361,6 +2961,10 @@
       "Population": 6715519
     },
     {
+      "Country": "Czech Republic",
+      "Population": 10333355
+    },
+    {
       "Country": "Germany",
       "Population": 79433029
     },
@@ -2375,6 +2979,10 @@
     {
       "Country": "France",
       "Population": 58261012
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 57247586
     },
     {
       "Country": "Croatia",
@@ -2401,6 +3009,14 @@
       "Population": 4241473
     },
     {
+      "Country": "Russia",
+      "Population": 147969406
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 5299187
+    },
+    {
       "Country": "Slovenia",
       "Population": 1998161
     },
@@ -2415,6 +3031,10 @@
     {
       "Country": "United States",
       "Population": 249623000
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 20464956
     }
   ],
   "1991-92": [
@@ -2439,6 +3059,10 @@
       "Population": 6799978
     },
     {
+      "Country": "Czech Republic",
+      "Population": 10308578
+    },
+    {
       "Country": "Germany",
       "Population": 80013896
     },
@@ -2453,6 +3077,10 @@
     {
       "Country": "France",
       "Population": 58554242
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 57424897
     },
     {
       "Country": "Croatia",
@@ -2479,6 +3107,14 @@
       "Population": 4261732
     },
     {
+      "Country": "Russia",
+      "Population": 148394216
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 5303294
+    },
+    {
       "Country": "Slovenia",
       "Population": 1999429
     },
@@ -2493,6 +3129,10 @@
     {
       "Country": "United States",
       "Population": 252981000
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 20962910
     }
   ],
   "1992-93": [
@@ -2517,6 +3157,10 @@
       "Population": 6875364
     },
     {
+      "Country": "Czech Republic",
+      "Population": 10319123
+    },
+    {
       "Country": "Germany",
       "Population": 80624598
     },
@@ -2531,6 +3175,10 @@
     {
       "Country": "France",
       "Population": 58846584
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 57580402
     },
     {
       "Country": "Croatia",
@@ -2557,6 +3205,14 @@
       "Population": 4286401
     },
     {
+      "Country": "Russia",
+      "Population": 148538197
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 5305016
+    },
+    {
       "Country": "Slovenia",
       "Population": 1996498
     },
@@ -2571,6 +3227,10 @@
     {
       "Country": "United States",
       "Population": 256514000
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 21485090
     }
   ],
   "1993-94": [
@@ -2595,6 +3255,10 @@
       "Population": 6938265
     },
     {
+      "Country": "Czech Republic",
+      "Population": 10329855
+    },
+    {
       "Country": "Germany",
       "Population": 81156363
     },
@@ -2609,6 +3273,10 @@
     {
       "Country": "France",
       "Population": 59103094
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 57718614
     },
     {
       "Country": "Croatia",
@@ -2635,6 +3303,14 @@
       "Population": 4311991
     },
     {
+      "Country": "Russia",
+      "Population": 148458777
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 5325305
+    },
+    {
       "Country": "Slovenia",
       "Population": 1991746
     },
@@ -2649,6 +3325,10 @@
     {
       "Country": "United States",
       "Population": 259919000
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 21987955
     }
   ],
   "1994-95": [
@@ -2673,6 +3353,10 @@
       "Population": 6993795
     },
     {
+      "Country": "Czech Republic",
+      "Population": 10333587
+    },
+    {
       "Country": "Germany",
       "Population": 81438348
     },
@@ -2687,6 +3371,10 @@
     {
       "Country": "France",
       "Population": 59324863
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 57865745
     },
     {
       "Country": "Croatia",
@@ -2713,6 +3401,14 @@
       "Population": 4336613
     },
     {
+      "Country": "Russia",
+      "Population": 148407912
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 5346331
+    },
+    {
       "Country": "Slovenia",
       "Population": 1989443
     },
@@ -2727,6 +3423,10 @@
     {
       "Country": "United States",
       "Population": 263126000
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 22463291
     }
   ],
   "1995-96": [
@@ -2751,6 +3451,10 @@
       "Population": 7040687
     },
     {
+      "Country": "Czech Republic",
+      "Population": 10327253
+    },
+    {
       "Country": "Germany",
       "Population": 81678051
     },
@@ -2765,6 +3469,10 @@
     {
       "Country": "France",
       "Population": 59541294
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 58019030
     },
     {
       "Country": "Croatia",
@@ -2791,6 +3499,14 @@
       "Population": 4359184
     },
     {
+      "Country": "Russia",
+      "Population": 148375787
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 5361999
+    },
+    {
       "Country": "Slovenia",
       "Population": 1989872
     },
@@ -2805,6 +3521,10 @@
     {
       "Country": "United States",
       "Population": 266278000
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 22917589
     }
   ],
   "1996-97": [
@@ -2829,6 +3549,10 @@
       "Population": 7071850
     },
     {
+      "Country": "Czech Republic",
+      "Population": 10315241
+    },
+    {
       "Country": "Germany",
       "Population": 81914831
     },
@@ -2843,6 +3567,10 @@
     {
       "Country": "France",
       "Population": 59754504
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 58166950
     },
     {
       "Country": "Croatia",
@@ -2869,6 +3597,14 @@
       "Population": 4381336
     },
     {
+      "Country": "Russia",
+      "Population": 148160129
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 5373361
+    },
+    {
       "Country": "Slovenia",
       "Population": 1988628
     },
@@ -2883,6 +3619,10 @@
     {
       "Country": "United States",
       "Population": 269394000
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 23351981
     }
   ],
   "1997-98": [
@@ -2907,6 +3647,10 @@
       "Population": 7088906
     },
     {
+      "Country": "Czech Republic",
+      "Population": 10304131
+    },
+    {
       "Country": "Germany",
       "Population": 82034771
     },
@@ -2921,6 +3665,10 @@
     {
       "Country": "France",
       "Population": 59968066
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 58316954
     },
     {
       "Country": "Croatia",
@@ -2947,6 +3695,14 @@
       "Population": 4405157
     },
     {
+      "Country": "Russia",
+      "Population": 147915361
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 5383291
+    },
+    {
       "Country": "Slovenia",
       "Population": 1985956
     },
@@ -2961,6 +3717,10 @@
     {
       "Country": "United States",
       "Population": 272657000
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 23758960
     }
   ],
   "1998-99": [
@@ -2985,6 +3745,10 @@
       "Population": 7110001
     },
     {
+      "Country": "Czech Republic",
+      "Population": 10294373
+    },
+    {
       "Country": "Germany",
       "Population": 82047195
     },
@@ -2999,6 +3763,10 @@
     {
       "Country": "France",
       "Population": 60190684
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 58487141
     },
     {
       "Country": "Croatia",
@@ -3025,6 +3793,14 @@
       "Population": 4431464
     },
     {
+      "Country": "Russia",
+      "Population": 147670784
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 5390516
+    },
+    {
       "Country": "Slovenia",
       "Population": 1981629
     },
@@ -3039,6 +3815,10 @@
     {
       "Country": "United States",
       "Population": 275854000
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 24134929
     }
   ],
   "1999-00": [
@@ -3063,6 +3843,10 @@
       "Population": 7143991
     },
     {
+      "Country": "Czech Republic",
+      "Population": 10283860
+    },
+    {
       "Country": "Germany",
       "Population": 82100243
     },
@@ -3077,6 +3861,10 @@
     {
       "Country": "France",
       "Population": 60501986
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 58682466
     },
     {
       "Country": "Croatia",
@@ -3103,6 +3891,14 @@
       "Population": 4461913
     },
     {
+      "Country": "Russia",
+      "Population": 147214776
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 5396020
+    },
+    {
       "Country": "Slovenia",
       "Population": 1983045
     },
@@ -3117,6 +3913,10 @@
     {
       "Country": "United States",
       "Population": 279040000
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 24476008
     }
   ],
   "2000-01": [
@@ -3141,6 +3941,10 @@
       "Population": 7184250
     },
     {
+      "Country": "Czech Republic",
+      "Population": 10255063
+    },
+    {
       "Country": "Germany",
       "Population": 82211508
     },
@@ -3155,6 +3959,10 @@
     {
       "Country": "France",
       "Population": 60918661
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 58892514
     },
     {
       "Country": "Croatia",
@@ -3181,6 +3989,14 @@
       "Population": 4490967
     },
     {
+      "Country": "Russia",
+      "Population": 146596869
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 5388720
+    },
+    {
       "Country": "Slovenia",
       "Population": 1988925
     },
@@ -3195,6 +4011,10 @@
     {
       "Country": "United States",
       "Population": 282162411
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 24787054
     }
   ],
   "2001-02": [
@@ -3219,6 +4039,10 @@
       "Population": 7229854
     },
     {
+      "Country": "Czech Republic",
+      "Population": 10216605
+    },
+    {
       "Country": "Germany",
       "Population": 82349925
     },
@@ -3233,6 +4057,10 @@
     {
       "Country": "France",
       "Population": 61364377
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 59119673
     },
     {
       "Country": "Croatia",
@@ -3259,6 +4087,14 @@
       "Population": 4513751
     },
     {
+      "Country": "Russia",
+      "Population": 145976482
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 5378867
+    },
+    {
       "Country": "Slovenia",
       "Population": 1992060
     },
@@ -3273,6 +4109,10 @@
     {
       "Country": "United States",
       "Population": 284968955
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 25090283
     }
   ],
   "2002-03": [
@@ -3297,6 +4137,10 @@
       "Population": 7284753
     },
     {
+      "Country": "Czech Republic",
+      "Population": 10196916
+    },
+    {
       "Country": "Germany",
       "Population": 82488495
     },
@@ -3311,6 +4155,10 @@
     {
       "Country": "France",
       "Population": 61812142
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 59370479
     },
     {
       "Country": "Croatia",
@@ -3337,6 +4185,14 @@
       "Population": 4538159
     },
     {
+      "Country": "Russia",
+      "Population": 145306497
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 5376912
+    },
+    {
       "Country": "Slovenia",
       "Population": 1994530
     },
@@ -3351,6 +4207,10 @@
     {
       "Country": "United States",
       "Population": 287625193
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 25399980
     }
   ],
   "2003-04": [
@@ -3375,6 +4235,10 @@
       "Population": 7339001
     },
     {
+      "Country": "Czech Republic",
+      "Population": 10193998
+    },
+    {
       "Country": "Germany",
       "Population": 82534176
     },
@@ -3389,6 +4253,10 @@
     {
       "Country": "France",
       "Population": 62249855
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 59647577
     },
     {
       "Country": "Croatia",
@@ -3415,6 +4283,14 @@
       "Population": 4564855
     },
     {
+      "Country": "Russia",
+      "Population": 144648618
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 5373374
+    },
+    {
       "Country": "Slovenia",
       "Population": 1995733
     },
@@ -3429,6 +4305,10 @@
     {
       "Country": "United States",
       "Population": 290107933
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 25711259
     }
   ],
   "2004-05": [
@@ -3453,6 +4333,10 @@
       "Population": 7389625
     },
     {
+      "Country": "Czech Republic",
+      "Population": 10197101
+    },
+    {
       "Country": "Germany",
       "Population": 82516260
     },
@@ -3467,6 +4351,10 @@
     {
       "Country": "France",
       "Population": 62707588
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 59987905
     },
     {
       "Country": "Croatia",
@@ -3493,6 +4381,14 @@
       "Population": 4591910
     },
     {
+      "Country": "Russia",
+      "Population": 144067316
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 5372280
+    },
+    {
       "Country": "Slovenia",
       "Population": 1997012
     },
@@ -3507,6 +4403,10 @@
     {
       "Country": "United States",
       "Population": 292805298
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 26029350
     }
   ],
   "2005-06": [
@@ -3531,6 +4431,10 @@
       "Population": 7437115
     },
     {
+      "Country": "Czech Republic",
+      "Population": 10211216
+    },
+    {
       "Country": "Germany",
       "Population": 82469422
     },
@@ -3545,6 +4449,10 @@
     {
       "Country": "France",
       "Population": 63180854
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 60401206
     },
     {
       "Country": "Croatia",
@@ -3571,6 +4479,14 @@
       "Population": 4623291
     },
     {
+      "Country": "Russia",
+      "Population": 143518814
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 5372807
+    },
+    {
       "Country": "Slovenia",
       "Population": 2000474
     },
@@ -3585,6 +4501,10 @@
     {
       "Country": "United States",
       "Population": 295516599
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 26356975
     }
   ],
   "2006-07": [
@@ -3609,6 +4529,10 @@
       "Population": 7483934
     },
     {
+      "Country": "Czech Republic",
+      "Population": 10238905
+    },
+    {
       "Country": "Germany",
       "Population": 82376451
     },
@@ -3623,6 +4547,10 @@
     {
       "Country": "France",
       "Population": 63622342
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 60846820
     },
     {
       "Country": "Croatia",
@@ -3649,6 +4577,14 @@
       "Population": 4660677
     },
     {
+      "Country": "Russia",
+      "Population": 143049637
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 5373054
+    },
+    {
       "Country": "Slovenia",
       "Population": 2006868
     },
@@ -3663,6 +4599,10 @@
     {
       "Country": "United States",
       "Population": 298379912
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 26699043
     }
   ],
   "2007-08": [
@@ -3687,6 +4627,10 @@
       "Population": 7551117
     },
     {
+      "Country": "Czech Republic",
+      "Population": 10298828
+    },
+    {
       "Country": "Germany",
       "Population": 82266372
     },
@@ -3701,6 +4645,10 @@
     {
       "Country": "France",
       "Population": 64016890
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 61322463
     },
     {
       "Country": "Croatia",
@@ -3727,6 +4675,14 @@
       "Population": 4709153
     },
     {
+      "Country": "Russia",
+      "Population": 142805114
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 5374622
+    },
+    {
       "Country": "Slovenia",
       "Population": 2018122
     },
@@ -3741,6 +4697,10 @@
     {
       "Country": "United States",
       "Population": 301231207
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 27076008
     }
   ],
   "2008-09": [
@@ -3765,6 +4725,10 @@
       "Population": 7647675
     },
     {
+      "Country": "Czech Republic",
+      "Population": 10384603
+    },
+    {
       "Country": "Germany",
       "Population": 82110097
     },
@@ -3779,6 +4743,10 @@
     {
       "Country": "France",
       "Population": 64375116
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 61806995
     },
     {
       "Country": "Croatia",
@@ -3805,6 +4773,14 @@
       "Population": 4768212
     },
     {
+      "Country": "Russia",
+      "Population": 142742366
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 5379233
+    },
+    {
       "Country": "Slovenia",
       "Population": 2021316
     },
@@ -3819,6 +4795,10 @@
     {
       "Country": "United States",
       "Population": 304093966
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 27494774
     }
   ],
   "2009-10": [
@@ -3843,6 +4823,10 @@
       "Population": 7743831
     },
     {
+      "Country": "Czech Republic",
+      "Population": 10443936
+    },
+    {
       "Country": "Germany",
       "Population": 81902307
     },
@@ -3857,6 +4841,10 @@
     {
       "Country": "France",
       "Population": 64706436
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 62276270
     },
     {
       "Country": "Croatia",
@@ -3883,6 +4871,14 @@
       "Population": 4828726
     },
     {
+      "Country": "Russia",
+      "Population": 142785348
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 5386406
+    },
+    {
       "Country": "Slovenia",
       "Population": 2039669
     },
@@ -3897,6 +4893,10 @@
     {
       "Country": "United States",
       "Population": 306771529
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 27939328
     }
   ],
   "2010-11": [
@@ -3921,6 +4921,10 @@
       "Population": 7824909
     },
     {
+      "Country": "Czech Republic",
+      "Population": 10474410
+    },
+    {
       "Country": "Germany",
       "Population": 81776930
     },
@@ -3935,6 +4939,10 @@
     {
       "Country": "France",
       "Population": 65026211
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 62766365
     },
     {
       "Country": "Croatia",
@@ -3961,6 +4969,14 @@
       "Population": 4889252
     },
     {
+      "Country": "Russia",
+      "Population": 142849468
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 5391428
+    },
+    {
       "Country": "Slovenia",
       "Population": 2048583
     },
@@ -3975,6 +4991,10 @@
     {
       "Country": "United States",
       "Population": 309327143
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 28385506
     }
   ],
   "2011-12": [
@@ -3999,6 +5019,10 @@
       "Population": 7912398
     },
     {
+      "Country": "Czech Republic",
+      "Population": 10496088
+    },
+    {
       "Country": "Germany",
       "Population": 80274983
     },
@@ -4013,6 +5037,10 @@
     {
       "Country": "France",
       "Population": 65340830
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 63258810
     },
     {
       "Country": "Croatia",
@@ -4039,6 +5067,14 @@
       "Population": 4953088
     },
     {
+      "Country": "Russia",
+      "Population": 143018195
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 5398384
+    },
+    {
       "Country": "Slovenia",
       "Population": 2052843
     },
@@ -4053,6 +5089,10 @@
     {
       "Country": "United States",
       "Population": 311583481
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 28823196
     }
   ],
   "2012-13": [
@@ -4077,6 +5117,10 @@
       "Population": 7996861
     },
     {
+      "Country": "Czech Republic",
+      "Population": 10510785
+    },
+    {
       "Country": "Germany",
       "Population": 80425823
     },
@@ -4091,6 +5135,10 @@
     {
       "Country": "France",
       "Population": 65657659
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 63700215
     },
     {
       "Country": "Croatia",
@@ -4117,6 +5165,14 @@
       "Population": 5018573
     },
     {
+      "Country": "Russia",
+      "Population": 143378447
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 5407579
+    },
+    {
       "Country": "Slovenia",
       "Population": 2057159
     },
@@ -4131,6 +5187,10 @@
     {
       "Country": "United States",
       "Population": 313877662
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 29261903
     }
   ],
   "2013-14": [
@@ -4155,6 +5215,10 @@
       "Population": 8089346
     },
     {
+      "Country": "Czech Republic",
+      "Population": 10514272
+    },
+    {
       "Country": "Germany",
       "Population": 80645605
     },
@@ -4169,6 +5233,10 @@
     {
       "Country": "France",
       "Population": 65997932
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 64128273
     },
     {
       "Country": "Croatia",
@@ -4195,6 +5263,14 @@
       "Population": 5079623
     },
     {
+      "Country": "Russia",
+      "Population": 143805638
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 5413393
+    },
+    {
       "Country": "Slovenia",
       "Population": 2059953
     },
@@ -4209,6 +5285,10 @@
     {
       "Country": "United States",
       "Population": 316059947
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 29724065
     }
   ],
   "2014-15": [
@@ -4233,6 +5313,10 @@
       "Population": 8188649
     },
     {
+      "Country": "Czech Republic",
+      "Population": 10525347
+    },
+    {
       "Country": "Germany",
       "Population": 80982500
     },
@@ -4247,6 +5331,10 @@
     {
       "Country": "France",
       "Population": 66312067
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 64602298
     },
     {
       "Country": "Croatia",
@@ -4273,6 +5361,14 @@
       "Population": 5137232
     },
     {
+      "Country": "Russia",
+      "Population": 144237223
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 5418649
+    },
+    {
       "Country": "Slovenia",
       "Population": 2061980
     },
@@ -4287,6 +5383,10 @@
     {
       "Country": "United States",
       "Population": 318386329
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 30222994
     }
   ],
   "2015-16": [
@@ -4311,6 +5411,10 @@
       "Population": 8282396
     },
     {
+      "Country": "Czech Republic",
+      "Population": 10546059
+    },
+    {
       "Country": "Germany",
       "Population": 81686611
     },
@@ -4325,6 +5429,10 @@
     {
       "Country": "France",
       "Population": 66548272
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 65116219
     },
     {
       "Country": "Croatia",
@@ -4351,6 +5459,14 @@
       "Population": 5188607
     },
     {
+      "Country": "Russia",
+      "Population": 144640716
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 5423801
+    },
+    {
       "Country": "Slovenia",
       "Population": 2063531
     },
@@ -4365,6 +5481,10 @@
     {
       "Country": "United States",
       "Population": 320738994
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 30749346
     }
   ],
   "2016-17": [
@@ -4389,6 +5509,10 @@
       "Population": 8373338
     },
     {
+      "Country": "Czech Republic",
+      "Population": 10566332
+    },
+    {
       "Country": "Germany",
       "Population": 82348669
     },
@@ -4403,6 +5527,10 @@
     {
       "Country": "France",
       "Population": 66724104
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 65611593
     },
     {
       "Country": "Croatia",
@@ -4429,6 +5557,14 @@
       "Population": 5234519
     },
     {
+      "Country": "Russia",
+      "Population": 145015460
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 5430798
+    },
+    {
       "Country": "Slovenia",
       "Population": 2065042
     },
@@ -4443,6 +5579,10 @@
     {
       "Country": "United States",
       "Population": 323071755
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 31284568
     }
   ],
   "2017-18": [
@@ -4467,6 +5607,10 @@
       "Population": 8451840
     },
     {
+      "Country": "Czech Republic",
+      "Population": 10594438
+    },
+    {
       "Country": "Germany",
       "Population": 82657002
     },
@@ -4481,6 +5625,10 @@
     {
       "Country": "France",
       "Population": 66918020
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 66058859
     },
     {
       "Country": "Croatia",
@@ -4507,6 +5655,14 @@
       "Population": 5276968
     },
     {
+      "Country": "Russia",
+      "Population": 145293260
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 5439232
+    },
+    {
       "Country": "Slovenia",
       "Population": 2066388
     },
@@ -4521,6 +5677,10 @@
     {
       "Country": "United States",
       "Population": 325122128
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 31819178
     }
   ],
   "2018-19": [
@@ -4545,6 +5705,10 @@
       "Population": 8514329
     },
     {
+      "Country": "Czech Republic",
+      "Population": 10629928
+    },
+    {
       "Country": "Germany",
       "Population": 82905782
     },
@@ -4559,6 +5723,10 @@
     {
       "Country": "France",
       "Population": 67158348
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 66460344
     },
     {
       "Country": "Croatia",
@@ -4585,6 +5753,14 @@
       "Population": 5311916
     },
     {
+      "Country": "Russia",
+      "Population": 145398106
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 5446771
+    },
+    {
       "Country": "Slovenia",
       "Population": 2073894
     },
@@ -4599,6 +5775,10 @@
     {
       "Country": "United States",
       "Population": 326838199
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 32373490
     }
   ],
   "2019-20": [
@@ -4623,6 +5803,10 @@
       "Population": 8575280
     },
     {
+      "Country": "Czech Republic",
+      "Population": 10671870
+    },
+    {
       "Country": "Germany",
       "Population": 83092962
     },
@@ -4637,6 +5821,10 @@
     {
       "Country": "France",
       "Population": 67382061
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 66836327
     },
     {
       "Country": "Croatia",
@@ -4663,6 +5851,14 @@
       "Population": 5347896
     },
     {
+      "Country": "Russia",
+      "Population": 145453291
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 5454147
+    },
+    {
       "Country": "Slovenia",
       "Population": 2088385
     },
@@ -4677,6 +5873,10 @@
     {
       "Country": "United States",
       "Population": 328329953
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 32964701
     }
   ],
   "2020-21": [
@@ -4701,6 +5901,10 @@
       "Population": 8638167
     },
     {
+      "Country": "Czech Republic",
+      "Population": 10697858
+    },
+    {
       "Country": "Germany",
       "Population": 83160871
     },
@@ -4715,6 +5919,10 @@
     {
       "Country": "France",
       "Population": 67601110
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 67081234
     },
     {
       "Country": "Croatia",
@@ -4741,6 +5949,14 @@
       "Population": 5379475
     },
     {
+      "Country": "Russia",
+      "Population": 145245148
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 5458827
+    },
+    {
       "Country": "Slovenia",
       "Population": 2102419
     },
@@ -4755,6 +5971,10 @@
     {
       "Country": "United States",
       "Population": 331526933
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 33586372
     }
   ],
   "2021-22": [
@@ -4779,6 +5999,10 @@
       "Population": 8704546
     },
     {
+      "Country": "Czech Republic",
+      "Population": 10505772
+    },
+    {
       "Country": "Germany",
       "Population": 83196078
     },
@@ -4793,6 +6017,10 @@
     {
       "Country": "France",
       "Population": 67842811
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 67026292
     },
     {
       "Country": "Croatia",
@@ -4819,6 +6047,14 @@
       "Population": 5408320
     },
     {
+      "Country": "Russia",
+      "Population": 144746762
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 5447247
+    },
+    {
       "Country": "Slovenia",
       "Population": 2108079
     },
@@ -4833,6 +6069,10 @@
     {
       "Country": "United States",
       "Population": 332048977
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 34243696
     }
   ],
   "2022-23": [
@@ -4857,6 +6097,10 @@
       "Population": 8777088
     },
     {
+      "Country": "Czech Republic",
+      "Population": 10672118
+    },
+    {
       "Country": "Germany",
       "Population": 83797985
     },
@@ -4871,6 +6115,10 @@
     {
       "Country": "France",
       "Population": 68065015
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 67791000
     },
     {
       "Country": "Croatia",
@@ -4897,6 +6145,14 @@
       "Population": 5457127
     },
     {
+      "Country": "Russia",
+      "Population": 144236933
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 5431752
+    },
+    {
       "Country": "Slovenia",
       "Population": 2112076
     },
@@ -4911,6 +6167,10 @@
     {
       "Country": "United States",
       "Population": 333271411
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 34938955
     }
   ],
   "2023-24": [
@@ -4935,6 +6195,10 @@
       "Population": 8888093
     },
     {
+      "Country": "Czech Republic",
+      "Population": 10864042
+    },
+    {
       "Country": "Germany",
       "Population": 83280000
     },
@@ -4949,6 +6213,10 @@
     {
       "Country": "France",
       "Population": 68287487
+    },
+    {
+      "Country": "United Kingdom",
+      "Population": 68350000
     },
     {
       "Country": "Croatia",
@@ -4975,6 +6243,14 @@
       "Population": 5519594
     },
     {
+      "Country": "Russia",
+      "Population": 143826130
+    },
+    {
+      "Country": "Slovakia",
+      "Population": 5426740
+    },
+    {
       "Country": "Slovenia",
       "Population": 2120461
     },
@@ -4989,6 +6265,10 @@
     {
       "Country": "United States",
       "Population": 334914895
+    },
+    {
+      "Country": "Uzbekistan",
+      "Population": 35652307
     }
   ]
 }


### PR DESCRIPTION
Added: 
- function works to make new league
- population differences of 10% are ignored to prevent short term changes of star players
- It works quickly, there's little buffer time and appears almost instantly


Needed now:
- small nationality changes are causing major changes when stars are filtered out and it doesn't make sense for recent years, add a buffer
- look into percentage of population the plays hockey differences. Even early years with U.S players pop in a star player when those years didn't have the infrastructure to create the players even after reducing by population
- The function is messy and has no tests. Refactor to take each part out so it is easier to understand, test, and change
- Need a re-simulate button, it also doesn't use the simulate button it runs on change year

closes #45 